### PR TITLE
Make parent worker process wait until horse process finishes

### DIFF
--- a/rq/worker.py
+++ b/rq/worker.py
@@ -435,7 +435,9 @@ class Worker(object):
             self.procline('Forked %d at %d' % (child_pid, time.time()))
             while True:
                 try:
+                    self.set_state('busy')
                     os.waitpid(child_pid, 0)
+                    self.set_state('idle')
                     break
                 except OSError as e:
                     # In case we encountered an OSError due to EINTR (which is


### PR DESCRIPTION
Worker should wait until horse process finishes.

Current implementation ends up raising a StopRequested exception, therefore stopping the parent process without waiting for the horse process to finish. 

python run_worker.py
11:07:33 RQ worker started, version 0.4.6
11:07:33
11:07:33 *** Listening on default...
11:07:33 default: fib.slow_fib(1) (9a94e99a-adbe-430a-a0ab-4656afd477ba)
^C11:07:34 Warm shut down requested.
Traceback (most recent call last):
  File "run_worker.py", line 11, in <module>
    Worker(q).work()
  File "/Users/javier.lopez/Dev/rq_test/src/rq/rq/worker.py", line 367, in work
    self.execute_job(job)
  File "/Users/javier.lopez/Dev/rq_test/src/rq/rq/worker.py", line 438, in execute_job
    os.waitpid(child_pid, 0)
  File "/Users/javier.lopez/Dev/rq_test/src/rq/rq/worker.py", line 331, in request_stop
    raise StopRequested()
rq.worker.StopRequested

A solution to this issue is to set the Parent Worker process state to "busy" before the os.waitpid call, this change makes parent process wait until horse process finishes.