### PR TITLE
Skip queue

### DIFF
--- a/rq/queue.py
+++ b/rq/queue.py
@@ -161,14 +161,18 @@ class Queue(object):
             if self.job_class.exists(job_id, self.connection):
                 self.connection.rpush(self.key, job_id)
 
-    def push_job_id(self, job_id, pipeline=None):
-        """Pushes a job ID on the corresponding Redis queue."""
+    def push_job_id(self, job_id, pipeline=None, skip_queue=False):
+        """Pushes a job ID on the corresponding Redis queue.
+        'skip_queue' allows you to push the job onto the front instead of the back of the queue"""
         connection = pipeline if pipeline is not None else self.connection
-        connection.rpush(self.key, job_id)
+        if skip_queue:
+            connection.lpush(self.key, job_id)
+        else:
+            connection.rpush(self.key, job_id)
 
     def enqueue_call(self, func, args=None, kwargs=None, timeout=None,
                      result_ttl=None, description=None, depends_on=None,
-                     job_id=None):
+                     job_id=None, skip_queue=False):
         """Creates a job to represent the delayed function call and enqueues
         it.
 
@@ -204,7 +208,7 @@ class Queue(object):
                     except WatchError:
                         continue
 
-        return self.enqueue_job(job)
+        return self.enqueue_job(job, skip_queue=skip_queue)
 
     def enqueue(self, f, *args, **kwargs):
         """Creates a job to represent the delayed function call and enqueues
@@ -231,6 +235,7 @@ class Queue(object):
         result_ttl = kwargs.pop('result_ttl', None)
         depends_on = kwargs.pop('depends_on', None)
         job_id = kwargs.pop('job_id', None)
+        skip_queue = kwargs.pop('skip_queue', False)
 
         if 'args' in kwargs or 'kwargs' in kwargs:
             assert args == (), 'Extra positional arguments cannot be used when using explicit args and kwargs.'  # noqa
@@ -240,9 +245,9 @@ class Queue(object):
         return self.enqueue_call(func=f, args=args, kwargs=kwargs,
                                  timeout=timeout, result_ttl=result_ttl,
                                  description=description, depends_on=depends_on,
-                                 job_id=job_id)
+                                 job_id=job_id, skip_queue=skip_queue)
 
-    def enqueue_job(self, job, set_meta_data=True):
+    def enqueue_job(self, job, set_meta_data=True, skip_queue=False):
         """Enqueues a job for delayed execution.
 
         If the `set_meta_data` argument is `True` (default), it will update
@@ -262,7 +267,7 @@ class Queue(object):
         job.save()
 
         if self._async:
-            self.push_job_id(job.id)
+            self.push_job_id(job.id, skip_queue=skip_queue)
         else:
             job.perform()
             job.save()

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -149,7 +149,7 @@ class Queue(object):
 
     def compact(self):
         """Removes all "dead" jobs from the queue by cycling through it, while
-        guarantueeing FIFO semantics.
+        guaranteeing FIFO semantics.
         """
         COMPACT_QUEUE = 'rq:queue:_compact:{0}'.format(uuid.uuid4())
 

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -161,18 +161,18 @@ class Queue(object):
             if self.job_class.exists(job_id, self.connection):
                 self.connection.rpush(self.key, job_id)
 
-    def push_job_id(self, job_id, pipeline=None, skip_queue=False):
+    def push_job_id(self, job_id, pipeline=None, at_front=False):
         """Pushes a job ID on the corresponding Redis queue.
-        'skip_queue' allows you to push the job onto the front instead of the back of the queue"""
+        'at_front' allows you to push the job onto the front instead of the back of the queue"""
         connection = pipeline if pipeline is not None else self.connection
-        if skip_queue:
+        if at_front:
             connection.lpush(self.key, job_id)
         else:
             connection.rpush(self.key, job_id)
 
     def enqueue_call(self, func, args=None, kwargs=None, timeout=None,
                      result_ttl=None, description=None, depends_on=None,
-                     job_id=None, skip_queue=False):
+                     job_id=None, at_front=False):
         """Creates a job to represent the delayed function call and enqueues
         it.
 
@@ -208,7 +208,7 @@ class Queue(object):
                     except WatchError:
                         continue
 
-        return self.enqueue_job(job, skip_queue=skip_queue)
+        return self.enqueue_job(job, at_front=at_front)
 
     def enqueue(self, f, *args, **kwargs):
         """Creates a job to represent the delayed function call and enqueues
@@ -235,7 +235,7 @@ class Queue(object):
         result_ttl = kwargs.pop('result_ttl', None)
         depends_on = kwargs.pop('depends_on', None)
         job_id = kwargs.pop('job_id', None)
-        skip_queue = kwargs.pop('skip_queue', False)
+        at_front = kwargs.pop('at_front', False)
 
         if 'args' in kwargs or 'kwargs' in kwargs:
             assert args == (), 'Extra positional arguments cannot be used when using explicit args and kwargs.'  # noqa
@@ -245,9 +245,9 @@ class Queue(object):
         return self.enqueue_call(func=f, args=args, kwargs=kwargs,
                                  timeout=timeout, result_ttl=result_ttl,
                                  description=description, depends_on=depends_on,
-                                 job_id=job_id, skip_queue=skip_queue)
+                                 job_id=job_id, at_front=at_front)
 
-    def enqueue_job(self, job, set_meta_data=True, skip_queue=False):
+    def enqueue_job(self, job, set_meta_data=True, at_front=False):
         """Enqueues a job for delayed execution.
 
         If the `set_meta_data` argument is `True` (default), it will update
@@ -267,7 +267,7 @@ class Queue(object):
         job.save()
 
         if self._async:
-            self.push_job_id(job.id, skip_queue=skip_queue)
+            self.push_job_id(job.id, at_front=at_front)
         else:
             job.perform()
             job.save()

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -466,6 +466,6 @@ class TestFailedQueue(RQTestCase):
         job1 = q.enqueue(say_hello)
         job2 = q.enqueue(say_hello)
         assert q.dequeue() == job1
-        skip_job = q.enqueue(say_hello, skip_queue=True)
+        skip_job = q.enqueue(say_hello, at_front=True)
         assert q.dequeue() == skip_job
         assert q.dequeue() == job2

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -459,3 +459,13 @@ class TestFailedQueue(RQTestCase):
         """Ensure custom job class assignment works as expected."""
         q = Queue(job_class=CustomJob)
         self.assertEqual(q.job_class, CustomJob)
+
+    def test_skip_queue(self):
+        """Ensure the skip_queue option functions"""
+        q = Queue('foo')
+        job1 = q.enqueue(say_hello)
+        job2 = q.enqueue(say_hello)
+        assert q.dequeue() == job1
+        skip_job = q.enqueue(say_hello, skip_queue=True)
+        assert q.dequeue() == skip_job
+        assert q.dequeue() == job2


### PR DESCRIPTION
You could view this as an alternative (and less-code) implementation of #452:

I ran into a situation where it would be very advantageous to queue a specific job *now* (instead of the end of the queue). So I implemented a `skip_queue` option the the various `Queue.enqueue` methods, which does an lpush instead of an rpush.

To accomplish #452 with this you'd enqueue each job specifying `skip_queue=True`. A better way to do this might be changing the default for `skip_queue` from `False` to `None`, and having the lowest level method here (`Queue.push_job_id()`) pull a default from the `Queue` (which we could set at initialization, default `False`). If this is desired renaming the argument from `skip_queue` to something more like `fifo` would likely be a good idea.

If the maintainers think this is a good idea/approach I'd be happy to implement it as part of this PR.