### PR TITLE
Pass named arguments to create a job in enqueue_call.

### DIFF
--- a/rq/queue.py
+++ b/rq/queue.py
@@ -179,7 +179,7 @@ class Queue(object):
         timeout = timeout or self._default_timeout
 
         # TODO: job with dependency shouldn't have "queued" as status
-        job = self.job_class.create(func, args, kwargs, connection=self.connection,
+        job = self.job_class.create(func, args=args, kwargs=kwargs, connection=self.connection,
                                     result_ttl=result_ttl, ttl=ttl, status=Status.QUEUED,
                                     description=description, depends_on=depends_on, timeout=timeout,
                                     id=job_id)


### PR DESCRIPTION
I'm subclassing `Queue` and `Job` to pass user authentication information to the background worker. This change makes it easier to access the explicit `kwargs` parameter in `Job.create`.
```
class MyJob(Job):

    @classmethod
    def create(cls, *args, **kwargs):
        """Adds authentication to RQ jobs"""
        if 'kwargs' in kwargs:
            user_id = kwargs['kwargs'].pop('user_id', None)
            do_something(user_id)
        super(YoJob, cls).create(*args, **kwargs)
```
Without this change, the explicit `kwargs` ends up in `args` for this overridden create function even though `kwargs` is a keyword argument in `Job.create`. Hope this makes sense.