### PR TITLE
Adding meta data: user_id and request_environ

### DIFF
--- a/rq/queue.py
+++ b/rq/queue.py
@@ -168,7 +168,8 @@ class Queue(object):
 
     def enqueue_call(self, func, args=None, kwargs=None, timeout=None,
                      result_ttl=None, ttl=None, description=None,
-                     user_id=None, depends_on=None, job_id=None):
+                     user_id=None, request_environ=None, depends_on=None,
+                     job_id=None):
         """Creates a job to represent the delayed function call and enqueues
         it.
 
@@ -182,7 +183,9 @@ class Queue(object):
         job = self.job_class.create(func, args=args, kwargs=kwargs, connection=self.connection,
                                     result_ttl=result_ttl, ttl=ttl, status=Status.QUEUED,
                                     description=description, user_id=user_id,
-                                    depends_on=depends_on, timeout=timeout, id=job_id)
+                                    request_environ=request_environ,
+                                    depends_on=depends_on,
+                                    timeout=timeout, id=job_id)
 
         # If job depends on an unfinished job, register itself on it's
         # parent's dependents instead of enqueueing it.
@@ -229,6 +232,7 @@ class Queue(object):
         timeout = kwargs.pop('timeout', None)
         description = kwargs.pop('description', None)
         user_id = kwargs.pop('user_id', None)
+        request_environ = kwargs.pop('request_environ', None)
         result_ttl = kwargs.pop('result_ttl', None)
         ttl = kwargs.pop('ttl', None)
         depends_on = kwargs.pop('depends_on', None)
@@ -242,7 +246,9 @@ class Queue(object):
         return self.enqueue_call(func=f, args=args, kwargs=kwargs,
                                  timeout=timeout, result_ttl=result_ttl, ttl=ttl,
                                  description=description, user_id=user_id,
-                                 depends_on=depends_on, job_id=job_id)
+                                 request_environ=request_environ,
+                                 depends_on=depends_on,
+                                 job_id=job_id)
 
     def enqueue_job(self, job, set_meta_data=True):
         """Enqueues a job for delayed execution.

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -179,7 +179,7 @@ class Queue(object):
         timeout = timeout or self._default_timeout
 
         # TODO: job with dependency shouldn't have "queued" as status
-        job = self.job_class.create(func, args, kwargs, connection=self.connection,
+        job = self.job_class.create(func, args=args, kwargs=kwargs, connection=self.connection,
                                     result_ttl=result_ttl, ttl=ttl, status=Status.QUEUED,
                                     description=description, depends_on=depends_on, timeout=timeout,
                                     id=job_id)

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -168,7 +168,7 @@ class Queue(object):
 
     def enqueue_call(self, func, args=None, kwargs=None, timeout=None,
                      result_ttl=None, ttl=None, description=None,
-                     depends_on=None, job_id=None):
+                     user_id=None, depends_on=None, job_id=None):
         """Creates a job to represent the delayed function call and enqueues
         it.
 
@@ -181,8 +181,8 @@ class Queue(object):
         # TODO: job with dependency shouldn't have "queued" as status
         job = self.job_class.create(func, args=args, kwargs=kwargs, connection=self.connection,
                                     result_ttl=result_ttl, ttl=ttl, status=Status.QUEUED,
-                                    description=description, depends_on=depends_on, timeout=timeout,
-                                    id=job_id)
+                                    description=description, user_id=user_id,
+                                    depends_on=depends_on, timeout=timeout, id=job_id)
 
         # If job depends on an unfinished job, register itself on it's
         # parent's dependents instead of enqueueing it.
@@ -228,6 +228,7 @@ class Queue(object):
         #     q.enqueue(foo, args=(1, 2), kwargs={'a': 1}, timeout=30)
         timeout = kwargs.pop('timeout', None)
         description = kwargs.pop('description', None)
+        user_id = kwargs.pop('user_id', None)
         result_ttl = kwargs.pop('result_ttl', None)
         ttl = kwargs.pop('ttl', None)
         depends_on = kwargs.pop('depends_on', None)
@@ -240,8 +241,8 @@ class Queue(object):
 
         return self.enqueue_call(func=f, args=args, kwargs=kwargs,
                                  timeout=timeout, result_ttl=result_ttl, ttl=ttl,
-                                 description=description, depends_on=depends_on,
-                                 job_id=job_id)
+                                 description=description, user_id=user_id,
+                                 depends_on=depends_on, job_id=job_id)
 
     def enqueue_job(self, job, set_meta_data=True):
         """Enqueues a job for delayed execution.

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -48,18 +48,19 @@ class TestJob(RQTestCase):
 
     def test_create_typical_job(self):
         """Creation of jobs for function calls."""
-        job = Job.create(func=some_calculation, args=(3, 4), kwargs=dict(z=2))
+        job = Job.create(func=some_calculation, args=(3, 4), kwargs=dict(z=2),
+                         user_id='abcd')
 
         # Jobs have a random UUID
         self.assertIsNotNone(job.id)
         self.assertIsNotNone(job.created_at)
-        self.assertIsNotNone(job.description)
         self.assertIsNone(job.instance)
 
         # Job data is set...
         self.assertEquals(job.func, some_calculation)
         self.assertEquals(job.args, (3, 4))
         self.assertEquals(job.kwargs, {'z': 2})
+        self.assertEquals(job.user_id, 'abcd')
 
         # ...but metadata is not
         self.assertIsNone(job.origin)
@@ -184,13 +185,15 @@ class TestJob(RQTestCase):
 
     def test_store_then_fetch(self):
         """Store, then fetch."""
-        job = Job.create(func=some_calculation, args=(3, 4), kwargs=dict(z=2))
+        job = Job.create(func=some_calculation, args=(3, 4), kwargs=dict(z=2),
+                         user_id='abcd')
         job.save()
 
         job2 = Job.fetch(job.id)
         self.assertEquals(job.func, job2.func)
         self.assertEquals(job.args, job2.args)
         self.assertEquals(job.kwargs, job2.kwargs)
+        self.assertEquals(job.user_id, job2.user_id)
 
         # Mathematical equation
         self.assertEquals(job, job2)


### PR DESCRIPTION
It is often useful to pass request environment information and user id information to the background worker from the front end. See below for an example code of how I use it with Flask for impersonation while processing background jobs. I also pass a serialized version of the wsgi environment (after converting buffers to strings) and recreate Flask `RequestContext`'s in the worker (mostly for logging purposes).

```
class CustomJob(Job):
    """Subclassing RQ Job to customize behavior"""

    def __init__(self, *args, **kwargs):
        super(YoJob, self).__init__(*args, **kwargs)

    # Job execution
    def perform(self):
        """Invokes the job function with the job arguments."""
        if self.request_environ:
            # If a request environment is attached to the job then we simulate
            # a real request environment.
            request_context = current_app.request_context(
                load_environ(self.request_environ))
        else:
            # Otherwise we use a test_request_context.
            request_context = current_app.test_request_context()

        with request_context:
            current_app.preprocess_request()
            if not g.identity.user and self.user_id:
                identity = Identity(self.user_id)
                # Set this identity on the thread.
                principals.set_identity(identity)
                # Tell listeners that the identity has changed.
                identity_changed.send(current_app, identity=identity)

            _job_stack.push(self.id)

            try:
                self._result = self.func(*self.args, **self.kwargs)
                response = make_json_response({'result': self._result})
                current_app.process_response(response)
            finally:
                assert self.id == _job_stack.pop()

            return self._result
```