### PR TITLE
Allow non-ASCII characters in arguments

### DIFF
--- a/rq/job.py
+++ b/rq/job.py
@@ -514,8 +514,15 @@ class Job(object):
         if self.func_name is None:
             return None
 
-        arg_list = [repr(arg) for arg in self.args]
-        arg_list += ['%s=%r' % (k, v) for k, v in self.kwargs.items()]
+        # Python 2/3 compatibility
+        try:
+            arg_list = [repr(arg).decode('utf-8') for arg in self.args]
+        except AttributeError:
+            arg_list = [repr(arg) for arg in self.args]
+
+        kwargs = ['{0}={1!r}'.format(k, v) for k, v in self.kwargs.items()]
+        # Sort here because python 3.3 & 3.4 makes different call_string
+        arg_list += sorted(kwargs)
         args = ', '.join(arg_list)
         return '%s(%s)' % (self.func_name, args)
 

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -23,6 +23,26 @@ except ImportError:
 
 
 class TestJob(RQTestCase):
+    def test_unicode(self):
+        """Unicode in job description [issue405]"""
+        job = Job.create(
+            'myfunc',
+            args=[12, "☃"],
+            kwargs=dict(snowman="☃", null=None),
+        )
+
+        try:
+            # Python 2
+            test_string = u"myfunc(12, u'\\u2603', null=None, snowman=u'\\u2603')".decode('utf-8')
+        except AttributeError:
+            # Python 3
+            test_string = "myfunc(12, '☃', null=None, snowman='☃')"
+
+        self.assertEquals(
+            job.description,
+            test_string,
+        )
+
     def test_create_empty_job(self):
         """Creation of new empty jobs."""
         job = Job()


### PR DESCRIPTION
get_call_string() failed if any arguments contained non-ASCII strings.

Fixes #406