### PR TITLE
Add missed `multi` command after `watch`

### DIFF
--- a/rq/queue.py
+++ b/rq/queue.py
@@ -199,6 +199,7 @@ class Queue(object):
                     try:
                         pipe.watch(depends_on.key)
                         if depends_on.get_status() != JobStatus.FINISHED:
+                            pipe.multi()
                             job.set_status(JobStatus.DEFERRED)
                             job.register_dependency(pipeline=pipe)
                             job.save(pipeline=pipe)


### PR DESCRIPTION
`watch` command should be used in conjunction with `multi` command
which was missed in enqueuing of job with dependencies.
I'm not sure about why `DEFERRED` status is set via different connection (not the current pipe). 
Fix #487