### PR TITLE
Add REDIS_SSL option in worker config file

### DIFF
--- a/rq/cli/helpers.py
+++ b/rq/cli/helpers.py
@@ -36,6 +36,7 @@ def get_redis_from_config(settings):
         port=settings.get('REDIS_PORT', 6379),
         db=settings.get('REDIS_DB', 0),
         password=settings.get('REDIS_PASSWORD', None),
+        ssl=settings.get('REDIS_SSL',False)
     )
 
 


### PR DESCRIPTION
Allow the worker to connect to a Redis instance through SSL (ex: Azure
Redis Cache use SSL only by default)

The following option is added to the worker optional config file: 
REDIS_SSL = True 