### PR TITLE
Improving logging.

### DIFF
--- a/rq/worker.py
+++ b/rq/worker.py
@@ -394,7 +394,7 @@ class Worker(object):
 
         did_perform_work = False
         self.register_birth()
-        self.log.info('RQ worker started, version %s' % VERSION)
+        self.log.info("RQ worker, '%s', started, version %s" % (self.key, VERSION))
         self.set_state(WorkerStatus.STARTED)
 
         try:
@@ -410,6 +410,8 @@ class Worker(object):
 
                     result = self.dequeue_job_and_maintain_ttl(timeout)
                     if result is None:
+                        if burst:
+                            self.log.info("RQ worker, '%s', has died." % self.key)
                         break
                 except StopRequested:
                     break

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -411,7 +411,7 @@ class Worker(object):
                     result = self.dequeue_job_and_maintain_ttl(timeout)
                     if result is None:
                         if burst:
-                            self.log.info("RQ worker, '%s', has died." % self.key)
+                            self.log.info("RQ worker, '%s', done, quitting." % self.key)
                         break
                 except StopRequested:
                     break


### PR DESCRIPTION
- Include worker key in worker startup log statement.
- Added a notification to make it more clear when a 'burst' worker dies.

```
rqworker --burst  
17:24:34 RQ worker, 'rq:worker:Trevors-MBP.26302', started, version 0.5.1
17:24:34 
17:24:34 *** Listening on default...
17:24:34 RQ worker, 'rq:worker:Trevors-MBP.26302', has died.
```