### PR TITLE
Enable proper setup of signale handlers for SimpleWorker as well.

### DIFF
--- a/rq/worker.py
+++ b/rq/worker.py
@@ -646,11 +646,6 @@ class Worker(object):
 
 
 class SimpleWorker(Worker):
-    def _install_signal_handlers(self, *args, **kwargs):
-        """Signal handlers are useless for test worker, as it
-        does not have fork() ability"""
-        pass
-
     def main_work_horse(self, *args, **kwargs):
         raise NotImplementedError("Test worker does not implement this method")
 


### PR DESCRIPTION
Fixes #523

This allows a SIGTERM to make the worker perform a warm shutdown and cleanly break out of the loop and finish the current job, if any.