### PR TITLE
Fixes #502

### DIFF
--- a/rq/job.py
+++ b/rq/job.py
@@ -417,6 +417,7 @@ class Job(object):
         self.result_ttl = int(obj.get('result_ttl')) if obj.get('result_ttl') else None  # noqa
         self._status = as_text(obj.get('status') if obj.get('status') else None)
         self._dependency_id = as_text(obj.get('dependency_id', None))
+        self.ttl = int(obj.get('ttl', -1))
         self.meta = unpickle(obj.get('meta')) if obj.get('meta') else {}
 
     def to_dict(self):
@@ -447,6 +448,8 @@ class Job(object):
             obj['dependency_id'] = self._dependency_id
         if self.meta:
             obj['meta'] = dumps(self.meta)
+        if self.ttl:
+            obj['ttl'] = self.ttl
 
         return obj
 
@@ -456,7 +459,7 @@ class Job(object):
         connection = pipeline if pipeline is not None else self.connection
 
         connection.hmset(key, self.to_dict())
-        self.cleanup(self.ttl)
+        self.cleanup(self.ttl, pipeline=connection)
 
     def cancel(self):
         """Cancels the given job, which will prevent the job from ever being

--- a/rq/job.py
+++ b/rq/job.py
@@ -417,7 +417,7 @@ class Job(object):
         self.result_ttl = int(obj.get('result_ttl')) if obj.get('result_ttl') else None  # noqa
         self._status = as_text(obj.get('status') if obj.get('status') else None)
         self._dependency_id = as_text(obj.get('dependency_id', None))
-        self.ttl = int(obj.get('ttl', -1))
+        self.ttl = int(obj.get('ttl')) if obj.get('ttl') else None
         self.meta = unpickle(obj.get('meta')) if obj.get('meta') else {}
 
     def to_dict(self):

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -2,8 +2,8 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-import time
 from datetime import datetime
+import time
 
 from tests import RQTestCase
 from tests.helpers import strip_microseconds
@@ -16,7 +16,7 @@ from rq.registry import DeferredJobRegistry
 from rq.utils import utcformat
 from rq.worker import Worker
 
-import fixtures
+from . import fixtures
 
 try:
     from cPickle import loads, dumps
@@ -104,8 +104,7 @@ class TestJob(RQTestCase):
         job = Job.create(func='tests.fixtures.say_hello', args=('World',))
 
         # Job data is set
-        self.assertTrue(job.func.func_code.co_filename in fixtures.say_hello.func_code.co_filename)
-        self.assertEquals(job.func.func_code.co_firstlineno, fixtures.say_hello.func_code.co_firstlineno)
+        self.assertEquals(job.func, fixtures.say_hello)
         self.assertIsNone(job.instance)
         self.assertEquals(job.args, ('World',))
 
@@ -149,7 +148,7 @@ class TestJob(RQTestCase):
 
         # Saving writes pickled job data
         unpickled_data = loads(self.testconn.hget(job.key, 'data'))
-        self.assertEquals(unpickled_data[0], 'fixtures.some_calculation')
+        self.assertEquals(unpickled_data[0], 'tests.fixtures.some_calculation')
 
     def test_fetch(self):
         """Fetching jobs."""
@@ -290,9 +289,9 @@ class TestJob(RQTestCase):
         job.save()
         Job.fetch(job.id, connection=self.testconn)
         if PY2:
-            self.assertEqual(job.description, "fixtures.say_hello(u'Lionel')")
+            self.assertEqual(job.description, "tests.fixtures.say_hello(u'Lionel')")
         else:
-            self.assertEqual(job.description, "fixtures.say_hello('Lionel')")
+            self.assertEqual(job.description, "tests.fixtures.say_hello('Lionel')")
 
     def test_job_access_outside_job_fails(self):
         """The current job is accessible only within a job context."""


### PR DESCRIPTION
Fixes some broken tests and misbehaviour with ttls. There was a temporal
coupling between saving the job and setting its expires parameter.