### PR TITLE
Allow non-ASCII characters in keyword arguments.

### DIFF
--- a/rq/job.py
+++ b/rq/job.py
@@ -518,7 +518,7 @@ class Job(object):
 
         arg_list = [as_text(repr(arg)) for arg in self.args]
 
-        kwargs = ['{0}={1!r}'.format(k, v) for k, v in self.kwargs.items()]
+        kwargs = ['{0}={1}'.format(k, as_text(repr(v))) for k, v in self.kwargs.items()]
         # Sort here because python 3.3 & 3.4 makes different call_string
         arg_list += sorted(kwargs)
         args = ', '.join(arg_list)


### PR DESCRIPTION
This is related to #492 (Allow non-ASCII characters in keyword arguments), it's followup #510 (change try/except in python2/3 compatibility to to_text()) and #406 (Handle Unicode in Job args & kwargs).

The patched `Job.get_call_string()` in #510 doesn't incorporate the use of `as_text` for allowing Unicode in kwargs, only for args. Under python 2.7 I was getting a UnicodeDecodeError ('ascii' codec can't decode byte) when a kwargs value contained a non-ASCII unicode character (é, or 0xc3 in this case).

Patching the formatting of the kwargs list using `as_text` in the same way as the args list, as in this PR, fixed the problem (note, I'm only patching the kwarg value here, not the kwarg key, which could in principle also have non-ASCII unicode characters).

There isn't an update to the `TestJob.test_unicode` test with this PR because I'm still scratching my head on that one. The current test does try to test unicode characters in kwargs, so I would have thought it would have failed. However, it looks to be a false positive test because the test passes even with the original implementation of `Job.get_call_string` that #492 patched. I.e. the method at [fac2b10](https://github.com/nvie/rq/blob/fac2b10309a7148b13cd259e6770f2695c126628/rq/job.py) (altered slightly to sort the kwargs list, for consistency with test ordering):

```python
def get_call_string(self):  # noqa
     """Returns a string representation of the call, formatted as a regular
    Python function invocation statement.
    """
    if self.func_name is None:
        return None

    arg_list = [repr(arg) for arg in self.args]
    arg_list += sorted(['%s=%r' % (k, v) for k, v in self.kwargs.items()])
    args = ', '.join(arg_list)
    return '%s(%s)' % (self.func_name, args)
```

Not completely sure why it passes at the moment (maybe related to the strings ("", '') within the context of the test being of type `unicode`, rather than `str`?).

This hasn't been tested under python 3 yet, but I'm assuming it should be okay because it's effectively the same patch to kwargs as was made to args.
