### PR TITLE
Added test coverage for unicode keyword argument support

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -78,6 +78,11 @@ class CallableObject(object):
         return u"I'm callable"
 
 
+class UnicodeStringObject(object):
+    def __repr__(self):
+        return u'é'.encode('utf-8')
+
+
 with Connection():
     @job(queue='default')
     def decorated_job(x, y):

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -11,7 +11,7 @@ import time
 
 from rq import Connection, get_current_job
 from rq.decorators import job
-
+from rq.compat import PY2
 
 def say_pid():
     return os.getpid()
@@ -80,7 +80,10 @@ class CallableObject(object):
 
 class UnicodeStringObject(object):
     def __repr__(self):
-        return u'é'.encode('utf-8')
+        if PY2:
+            return u'é'.encode('utf-8')
+        else:
+            return u'é'
 
 
 with Connection():

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -399,3 +399,11 @@ class TestJob(RQTestCase):
         job.perform()
 
         self.assertRaises(TypeError, queue.enqueue, fixtures.say_hello, job_id=1234)
+
+    def test_get_call_string_unicode(self):
+        """test call string with unicode keyword arguments"""
+        queue = Queue(connection=self.testconn)
+
+        job = queue.enqueue(fixtures.echo, arg_with_unicode=fixtures.UnicodeStringObject())
+        self.assertIsNotNone(job.get_call_string())
+        job.perform()


### PR DESCRIPTION
Added test coverage for unicode keyword argument support in method signatures (#536). Confirmed that this fails pre-536, and passes post-536.