### PR TITLE
Refresh job data before sending job to exception handlers

### DIFF
--- a/rq/worker.py
+++ b/rq/worker.py
@@ -523,6 +523,7 @@ class Worker(object):
                 pipeline.execute()
 
             except Exception:
+                job.refresh()
                 job.set_status(Status.FAILED, pipeline=pipeline)
                 started_job_registry.remove(job, pipeline=pipeline)
                 pipeline.execute()


### PR DESCRIPTION
Currently the job instance given to the exception handlers is the one created during enqueueing. This PR simply calls the refresh method to have the job data as it was at the moment the exception happened.
Someone using a custom exception handler can use for example job.meta to decide on how to handle exceptions.

Note: I did not immediately see a way to add this call to the pipeline since within refresh() redis data is needed.