### PR TITLE
support multiple queues on dependent jobs

### DIFF
--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -5,7 +5,7 @@ from __future__ import (absolute_import, division, print_function,
 from datetime import datetime
 import time
 
-from tests import RQTestCase
+from tests import RQTestCase, fixtures
 from tests.helpers import strip_microseconds
 
 from rq.compat import PY2, as_text
@@ -16,7 +16,7 @@ from rq.registry import DeferredJobRegistry
 from rq.utils import utcformat
 from rq.worker import Worker
 
-from . import fixtures
+
 
 try:
     from cPickle import loads, dumps

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -350,8 +350,9 @@ class TestQueue(RQTestCase):
         # DeferredJobRegistry should also be empty
         self.assertEqual(registry.get_job_ids(), [])
 
+
     def test_enqueue_dependents_on_multiple_queues(self):
-        """Enqueueing dependent jobs pushes all jobs in the depends set to the queue
+        """Enqueueing dependent jobs on multiple queues pushes jobs in the queues
         and removes them from DeferredJobRegistry for each different queue."""
         q_1 = Queue("queue_1")
         q_2 = Queue("queue_2")


### PR DESCRIPTION
Current implementation is using the first job queue to insert all dependent jobs, ignoring the queue where the jobs were enqueued.

With this change, we will use job origin attribute to fetch the original queue, then insert the dependent job to the fetched queue.

fixes issue #512 