### PR TITLE
log job result in DEBUG level and truncate to 2k symbols

### DIFF
--- a/rq/worker.py
+++ b/rq/worker.py
@@ -602,8 +602,6 @@ class Worker(object):
         self.log.info(green('Job OK'))
         if rv:
             log_result = "{0!r}".format(text_type(rv))
-            if len(log_result) > 2000:
-                log_result = "{0}..\n..output truncated".format(log_result[:2000])
             self.log.debug('Result: {0}'.format(yellow(log_result)))
 
         if result_ttl == 0:

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -603,8 +603,8 @@ class Worker(object):
         if rv:
             log_result = "{0!r}".format(text_type(rv))
             if len(log_result) > 2000:
-                log_result = "{}..\n..output truncated".format(log_result[:2000])
-            self.log.debug('Result: {}'.format(yellow(log_result)))
+                log_result = "{0}..\n..output truncated".format(log_result[:2000])
+            self.log.debug('Result: {0}'.format(yellow(log_result)))
 
         if result_ttl == 0:
             self.log.info('Result discarded immediately')

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -599,10 +599,12 @@ class Worker(object):
                 self.handle_exception(job, *sys.exc_info())
                 return False
 
-        if rv is None:
-            self.log.info('Job OK')
-        else:
-            self.log.info('Job OK, result = {0!r}'.format(yellow(text_type(rv))))
+        self.log.info(green('Job OK'))
+        if rv:
+            log_result = "{0!r}".format(text_type(rv))
+            if len(log_result) > 2000:
+                log_result = "{}..\n..output truncated".format(log_result[:2000])
+            self.log.debug('Result: {}'.format(yellow(log_result)))
 
         if result_ttl == 0:
             self.log.info('Result discarded immediately')


### PR DESCRIPTION
I think it makes sense moving output to DEBUG as you'd care about it in logs only while debugging. Over certain size the output in logs also gets quite unwieldy, so truncating it to 2k chars.

Keep up the good work and let me know if things should be done differently!