### PR TITLE
export worker id and job id as env vars to work horse

### DIFF
--- a/rq/worker.py
+++ b/rq/worker.py
@@ -491,6 +491,8 @@ class Worker(object):
         within the given timeout bounds, or will end the work horse with
         SIGALRM.
         """
+        os.environ['RQ_WORKER_ID'] = self.name
+        os.environ['RQ_JOB_ID'] = job.id
         child_pid = os.fork()
         if child_pid == 0:
             self.main_work_horse(job)


### PR DESCRIPTION
This was initially spurred by #479. Idea behind doing this:

 + including worker id and job id in logs and relevant HTTP request headers
 + no additional redis connection or request required
 + no API change: workers can look for env vars and use them if found

Environment variables can be abused much as global variables often are, but they feel like a good fit here for communicating contextual read-only information from the parent worker to the child work horse process.
