### PR TITLE
more info in 'Job OK' log entry

### DIFF
--- a/rq/worker.py
+++ b/rq/worker.py
@@ -599,7 +599,7 @@ class Worker(object):
                 self.handle_exception(job, *sys.exc_info())
                 return False
 
-        self.log.info(green('Job OK'))
+        self.log.info('{0}: {1} ({2})'.format(green(job.origin), blue('Job OK'), job.id))
         if rv:
             log_result = "{0!r}".format(as_text(text_type(rv)))
             self.log.debug('Result: {0}'.format(yellow(log_result)))


### PR DESCRIPTION
Changed to mirror the [job started](https://github.com/nvie/rq/blob/master/rq/worker.py#L461-L462) log entry.

The current simple "Job OK" message is pretty useless if you have multiple queues executing jobs, it can take ages work out which job was ok and it's impossible if you have multiple workers running and can't differentiate between their logs.