### PR TITLE
mark as busy before forking horse

### DIFF
--- a/rq/worker.py
+++ b/rq/worker.py
@@ -428,7 +428,9 @@ class Worker(object):
                     break
 
                 job, queue = result
+                self.set_state('busy')
                 self.execute_job(job)
+                self.set_state('idle')
                 self.heartbeat()
 
                 if job.get_status() == JobStatus.FINISHED:


### PR DESCRIPTION
Set the worker to busy before forking a work horse. Without this fix, only the work horse is set to busy. Thus, when sending SIGINT to the worker, the worker itself will die immediately and leave the horse working in an uncontrolled way.