### PR TITLE
[Docs] Prevent running worker when the connection instance is imported

### DIFF
--- a/patterns/index.md
+++ b/patterns/index.md
@@ -31,9 +31,10 @@ urlparse.uses_netloc.append('redis')
 url = urlparse.urlparse(redis_url)
 conn = Redis(host=url.hostname, port=url.port, db=0, password=url.password)
 
-with Connection(conn):
-    worker = Worker(map(Queue, listen))
-    worker.work()
+if __name__ == '__main__':
+    with Connection(conn):
+        worker = Worker(map(Queue, listen))
+        worker.work()
 {% endhighlight %}
 
 Than, add the command to your `Procfile`:


### PR DESCRIPTION
Heroku Example:
When importing the redis connection instance from another file,
the worker is run immediately, blocking the execution of the rest of
the code.
This fixes the worker to only be run only if the worker is executed from
the command line and not when imported.
[Sample Use Case](https://devcenter.heroku.com/articles/python-rq)