### PR TITLE
Allow meta when enqueing

### DIFF
--- a/rq/job.py
+++ b/rq/job.py
@@ -89,7 +89,7 @@ class Job(object):
     @classmethod
     def create(cls, func, args=None, kwargs=None, connection=None,
                result_ttl=None, ttl=None, status=None, description=None,
-               depends_on=None, timeout=None, id=None, origin=None):
+               depends_on=None, timeout=None, id=None, origin=None, meta=None):
         """Creates a new Job instance for the given function, arguments, and
         keyword arguments.
         """
@@ -133,6 +133,7 @@ class Job(object):
         job.ttl = ttl
         job.timeout = timeout
         job._status = status
+        job.meta = meta or {}
 
         # dependency could be job instance or id
         if depends_on is not None:

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -175,7 +175,7 @@ class Queue(object):
 
     def enqueue_call(self, func, args=None, kwargs=None, timeout=None,
                      result_ttl=None, ttl=None, description=None,
-                     depends_on=None, job_id=None, at_front=False):
+                     depends_on=None, job_id=None, at_front=False, meta=None):
         """Creates a job to represent the delayed function call and enqueues
         it.
 
@@ -189,7 +189,7 @@ class Queue(object):
             func, args=args, kwargs=kwargs, connection=self.connection,
             result_ttl=result_ttl, ttl=ttl, status=JobStatus.QUEUED,
             description=description, depends_on=depends_on,
-            timeout=timeout, id=job_id, origin=self.name)
+            timeout=timeout, id=job_id, origin=self.name, meta=meta)
 
         # If job depends on an unfinished job, register itself on it's
         # parent's dependents instead of enqueueing it.
@@ -249,6 +249,7 @@ class Queue(object):
         depends_on = kwargs.pop('depends_on', None)
         job_id = kwargs.pop('job_id', None)
         at_front = kwargs.pop('at_front', False)
+        meta = kwargs.pop('meta', None)
 
         if 'args' in kwargs or 'kwargs' in kwargs:
             assert args == (), 'Extra positional arguments cannot be used when using explicit args and kwargs'  # noqa
@@ -258,7 +259,7 @@ class Queue(object):
         return self.enqueue_call(func=f, args=args, kwargs=kwargs,
                                  timeout=timeout, result_ttl=result_ttl, ttl=ttl,
                                  description=description, depends_on=depends_on,
-                                 job_id=job_id, at_front=at_front)
+                                 job_id=job_id, at_front=at_front, meta=meta)
 
     def enqueue_job(self, job, pipeline=None, at_front=False):
         """Enqueues a job for delayed execution.

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -272,6 +272,13 @@ class TestQueue(RQTestCase):
         job = q.enqueue(say_hello)
         self.assertEqual(job.get_status(), JobStatus.QUEUED)
 
+    def test_enqueue_meta_arg(self):
+        """enqueue() can set the job.meta contents."""
+        q = Queue()
+        job = q.enqueue(say_hello, meta={'foo': 'bar', 'baz': 42})
+        self.assertEqual(job.meta['foo'], 'bar')
+        self.assertEqual(job.meta['baz'], 42)
+
     def test_enqueue_explicit_args(self):
         """enqueue() works for both implicit/explicit args."""
         q = Queue()


### PR DESCRIPTION
Makes it very easy to add meta data to a Job in the Queue.enqueue call. Currently you would have to create the Job separately, set its metadata and then call enqueue_job. This way you only need to provide the 'meta' keyword arg to the enqueue call and you're set.

This was mentioned in issue #528 too.

Let me know what you think.

Thanks

-Tim