### PR TITLE
Fixes #613

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 redis>=2.7
-click>=3.0.0
+click<6.0

--- a/rq/compat/connections.py
+++ b/rq/compat/connections.py
@@ -22,9 +22,6 @@ PATCHED_METHODS = ['_setex', '_lrem', '_zadd', '_pipeline', '_ttl']
 
 
 def patch_connection(connection):
-    if not isinstance(connection, StrictRedis):
-        raise ValueError('A StrictRedis or Redis connection is required.')
-
     # Don't patch already patches objects
     if all([hasattr(connection, attr) for attr in PATCHED_METHODS]):
         return connection
@@ -38,7 +35,8 @@ def patch_connection(connection):
         if hasattr(connection, 'pttl'):
             connection._pttl = fix_return_type(partial(StrictRedis.pttl, connection))
 
-    elif isinstance(connection, StrictRedis):
+    # add support for mock redis objects
+    elif hasattr(connection, 'setex'):
         connection._setex = connection.setex
         connection._lrem = connection.lrem
         connection._zadd = connection.zadd


### PR DESCRIPTION
This has been discussed in #514, #282 and #88.

Using an explicit type check via `isinstance`, rather than duck typing, is typically considered unpythonic and breaks compatibility with mock objects such as FakeRedis. This patches removes the type check, and instead looks for a common method that should be present on the object as a hint on whether it's compatible or not.