### PR TITLE
Correction to results-ttl value on worker command

### DIFF
--- a/rq/cli/cli.py
+++ b/rq/cli/cli.py
@@ -144,7 +144,7 @@ def info(url, config, path, interval, raw, only_queues, only_workers, by_queue, 
 @click.option('--job-class', '-j', default='rq.job.Job', help='RQ Job class to use')
 @click.option('--queue-class', default='rq.Queue', help='RQ Queue class to use')
 @click.option('--path', '-P', default='.', help='Specify the import path.')
-@click.option('--results-ttl', help='Default results timeout to be used')
+@click.option('--results-ttl', type=int, help='Default results timeout to be used')
 @click.option('--worker-ttl', type=int, help='Default worker timeout to be used')
 @click.option('--verbose', '-v', is_flag=True, help='Show more output')
 @click.option('--quiet', '-q', is_flag=True, help='Show less output')


### PR DESCRIPTION
The `--results-ttl` value isn't currently being cast as an integer when passed from the command line, this causes issues further down when a value is sent as it remains a string i.e:

```
..../site-packages/rq/registry.py", line 32, in add
     score = ttl if ttl < 0 else current_timestamp() + ttl
TypeError: unorderable types: str() < int()
```

Fixed to cast value as integer.