### PR TITLE
When not async set job finished

### DIFF
--- a/rq/queue.py
+++ b/rq/queue.py
@@ -217,6 +217,7 @@ class Queue(object):
 
         if not self._async:
             job.perform()
+            job.set_status(JobStatus.FINISHED)
             job.save()
             job.cleanup(DEFAULT_RESULT_TTL)
 

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -10,7 +10,7 @@ from tests.helpers import strip_microseconds
 
 from rq.compat import PY2, as_text
 from rq.exceptions import NoSuchJobError, UnpickleError
-from rq.job import Job, get_current_job
+from rq.job import Job, get_current_job, JobStatus
 from rq.queue import Queue
 from rq.registry import DeferredJobRegistry
 from rq.utils import utcformat
@@ -306,6 +306,12 @@ class TestJob(RQTestCase):
     def test_job_access_within_synchronous_job_function(self):
         queue = Queue(async=False)
         queue.enqueue(fixtures.access_self)
+
+    def test_job_async_status_finished(self):
+        queue = Queue(async=False)
+        job = queue.enqueue(fixtures.say_hello)
+        self.assertEqual(job.result, 'Hi there, Stranger!')
+        self.assertEqual(job.get_status(), JobStatus.FINISHED)
 
     def test_get_result_ttl(self):
         """Getting job result TTL."""


### PR DESCRIPTION
When you're working in not `async` mode (usually when debugging) and you're checking if the job is finished, never is finished because the `worker` sets the `FINISHED` status.

With this patch the job is marked as finished when working in async mode.