### PR TITLE
Worker only creates log handlers if there aren't any.

### DIFF
--- a/rq/logutils.py
+++ b/rq/logutils.py
@@ -16,10 +16,25 @@ from rq.utils import ColorizingStreamHandler
 
 def setup_loghandlers(level='INFO'):
     logger = logging.getLogger('rq.worker')
-    if not logger.handlers:
+    if not _has_effective_handler(logger):
         logger.setLevel(level)
         formatter = logging.Formatter(fmt='%(asctime)s %(message)s',
                                       datefmt='%H:%M:%S')
         handler = ColorizingStreamHandler()
         handler.setFormatter(formatter)
         logger.addHandler(handler)
+
+
+def _has_effective_handler(logger):
+    """
+    Checks if a logger has a handler that will catch its messages in its logger hierarchy.
+    :param `logging.Logger` logger: The logger to be checked.
+    :return: True if a handler is found for the logger, False otherwise.
+    :rtype: bool
+    """
+    while True:
+        if logger.handlers:
+            return True
+        if not logger.parent:
+            return False
+        logger = logger.parent


### PR DESCRIPTION
I am running worker on a separate process starting from my app using `multiprocessing`. My application configures the logs, but the worker class also wants to do it (actually, it just adds one handler). The effect is that logs from worker are doubled and don't go to the stream I want.

I hope that I understood the original intention behind this code.