### PR TITLE
docs: Use rq command instead of rqworker/rqinfo

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -23,10 +23,10 @@ It can also be integrated easily in your Flask app.
 
 ## Monitoring at the console
 
-To see what queues exist and what workers are active, just type `rqinfo`:
+To see what queues exist and what workers are active, just type `rq info`:
 
 {% highlight console %}
-$ rqinfo
+$ rq info
 high       |██████████████████████████ 20
 low        |██████████████ 12
 default    |█████████ 8
@@ -44,7 +44,7 @@ Bricktop.18349 idle: default
 You can also query for a subset of queues, if you're looking for specific ones:
 
 {% highlight console %}
-$ rqinfo high default
+$ rq info high default
 high       |██████████████████████████ 20
 default    |█████████ 8
 2 queues, 28 jobs total
@@ -57,11 +57,11 @@ Bricktop.18349 idle: default
 
 ## Organising workers by queue
 
-By default, `rqinfo` prints the workers that are currently active, and the
+By default, `rq info` prints the workers that are currently active, and the
 queues that they are listening on, like this:
 
 {% highlight console %}
-$ rqinfo
+$ rq info
 ...
 
 Mickey.26421 idle: high, default
@@ -74,7 +74,7 @@ To see the same data, but organised by queue, use the `-R` (or `--by-queue`)
 flag:
 
 {% highlight console %}
-$ rqinfo -R
+$ rq info -R
 ...
 
 high:    Bricktop.25458 (busy), Mickey.26421 (idle), Turkish.25812 (busy)
@@ -87,19 +87,19 @@ failed:  –
 
 ## Interval polling
 
-By default, `rqinfo` will print stats and exit.
+By default, `rq info` will print stats and exit.
 You can specify a poll interval, by using the `--interval` flag.
 
 {% highlight console %}
-$ rqinfo --interval 1
+$ rq info --interval 1
 {% endhighlight %}
 
-`rqinfo` will now update the screen every second.  You may specify a float
+`rq info` will now update the screen every second.  You may specify a float
 value to indicate fractions of seconds.  Be aware that low interval values will
 increase the load on Redis, of course.
 
 {% highlight console %}
-$ rqinfo --interval 0.5
+$ rq info --interval 0.5
 {% endhighlight %}
 
 [dashboard]: https://github.com/nvie/rq-dashboard

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -14,7 +14,7 @@ To start crunching work, simply start a worker from the root of your project
 directory:
 
 {% highlight console %}
-$ rqworker high normal low
+$ rq worker high normal low
 *** Listening for work on high, normal, low
 Got send_newsletter('me@nvie.com') from default
 Job ended normally without result
@@ -38,7 +38,7 @@ mode_ to finish all currently available work and quit as soon as all given
 queues are emptied.
 
 {% highlight console %}
-$ rqworker --burst high normal low
+$ rq worker --burst high normal low
 *** Listening for work on high, normal, low
 Got send_newsletter('me@nvie.com') from default
 Job ended normally without result
@@ -77,7 +77,7 @@ The life-cycle of a worker consists of a few phases:
 
 ## Performance notes
 
-Basically the `rqworker` shell script is a simple fetch-fork-execute loop.
+Basically the `rq worker` shell script is a simple fetch-fork-execute loop.
 When a lot of your jobs do lengthy setups, or they all depend on the same set
 of modules, you pay this overhead each time you run a job (since you're doing
 the import _after_ the moment of forking).  This is clean, because RQ won't
@@ -88,7 +88,7 @@ jobs can be to import the necessary modules _before_ the fork.  There is no way
 of telling RQ workers to perform this set up for you, but you can do it
 yourself before starting the work loop.
 
-To do this, provide your own worker script (instead of using `rqworker`).
+To do this, provide your own worker script (instead of using `rq worker`).
 A simple implementation example:
 
 {% highlight python %}
@@ -100,7 +100,7 @@ from rq import Queue, Connection, Worker
 import library_that_you_want_preloaded
 
 # Provide queue names to listen to as arguments to this script,
-# similar to rqworker
+# similar to rq worker
 with Connection():
     qs = map(Queue, sys.argv[1:]) or [Queue()]
 
@@ -134,7 +134,7 @@ will still try to register its own death.
 
 _New in version 0.3.2._
 
-If you'd like to configure `rqworker` via a configuration file instead of
+If you'd like to configure `rq worker` via a configuration file instead of
 through command line arguments, you can do this by creating a Python file like
 `settings.py`:
 
@@ -162,7 +162,7 @@ _Note: The_ `QUEUES` _and_ `REDIS_PASSWORD` _settings are new since 0.3.3._
 To specify which module to read settings from, use the `-c` option:
 
 {% highlight console %}
-$ rqworker -c settings
+$ rq worker -c settings
 {% endhighlight %}
 
 
@@ -181,7 +181,7 @@ more common requests so far are:
 You can use the `-w` option to specify a different worker class to use:
 
 {% highlight console %}
-$ rqworker -w 'path.to.GeventWorker'
+$ rq worker -w 'path.to.GeventWorker'
 {% endhighlight %}
 
 
@@ -190,11 +190,11 @@ $ rqworker -w 'path.to.GeventWorker'
 _New in version 0.5.5._
 
 If you need to handle errors differently for different types of jobs, or simply want to customize
-RQ's default error handling behavior, run `rqworker` using the `--exception-handler` option:
+RQ's default error handling behavior, run `rq worker` using the `--exception-handler` option:
 
 {% highlight console %}
-$ rqworker --exception-handler 'path.to.my.ErrorHandler'
+$ rq worker --exception-handler 'path.to.my.ErrorHandler'
 
 # Multiple exception handlers is also supported
-$ rqworker --exception-handler 'path.to.my.ErrorHandler' --exception-handler 'another.ErrorHandler'
+$ rq worker --exception-handler 'path.to.my.ErrorHandler' --exception-handler 'another.ErrorHandler'
 {% endhighlight %}

--- a/index.md
+++ b/index.md
@@ -51,7 +51,7 @@ To start executing enqueued function calls in the background, start a worker
 from your project's directory:
 
 {% highlight console %}
-$ rqworker
+$ rq worker
 *** Listening for work on default
 Got count_words_at_url('http://nvie.com') from default
 Job result = 818

--- a/patterns/django.md
+++ b/patterns/django.md
@@ -19,5 +19,5 @@ environmental variable will already do the trick.
 If `settings.py` is your Django settings file (as it is by default), use this:
 
 {% highlight console %}
-$ DJANGO_SETTINGS_MODULE=settings rqworker high default low
+$ DJANGO_SETTINGS_MODULE=settings rq worker high default low
 {% endhighlight %}

--- a/patterns/supervisor.md
+++ b/patterns/supervisor.md
@@ -15,12 +15,12 @@ use the following supervisor settings:
 
 {% highlight ini %}
 [program:myworker]
-; Point the command to the specific rqworker command you want to run.
+; Point the command to the specific rq command you want to run.
 ; If you use virtualenv, be sure to point it to
-; /path/to/virtualenv/bin/rqworker
+; /path/to/virtualenv/bin/rq
 ; Also, you probably want to include a settings module to configure this
 ; worker.  For more info on that, see http://python-rq.org/docs/workers/
-command=/path/to/rqworker -c mysettings high normal low
+command=/path/to/rq worker -c mysettings high normal low
 process_name=%(program_name)s
 
 ; If you want to run more than one worker instance, increase this


### PR DESCRIPTION
It is confusing to newbie like me whether to use `rqworker` or `rq worker`. According to [the source code](https://github.com/nvie/rq/blob/0.5.6/setup.py#L48-L49), use of `rq worker` seems to be recommended rather than `rqworker`. So this pull request replaces all the `rqworker` and `rqinfo` with `rq worker` and `rq info` in the documentation.