### PR TITLE
Accept byte strings as the first argument of Worker() in Python 2

### DIFF
--- a/rq/worker.py
+++ b/rq/worker.py
@@ -128,7 +128,7 @@ class Worker(object):
             connection = get_current_connection()
         self.connection = connection
 
-        queues = [self.queue_class(name=q) if isinstance(q, text_type) else q
+        queues = [self.queue_class(name=q) if isinstance(q, string_types) else q
                   for q in ensure_list(queues)]
         self._name = name
         self.queues = queues
@@ -176,7 +176,7 @@ class Worker(object):
         """Sanity check for the given queues."""
         for queue in self.queues:
             if not isinstance(queue, self.queue_class):
-                raise TypeError('{0} is not of type {1} or text type'.format(queue, self.queue_class))
+                raise TypeError('{0} is not of type {1} or string types'.format(queue, self.queue_class))
 
     def queue_names(self):
         """Returns the queue names of this worker's queues."""

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -15,7 +15,7 @@ from tests.fixtures import (create_file, create_file_after_timeout,
 from tests.helpers import strip_microseconds
 
 from rq import get_failed_queue, Queue, SimpleWorker, Worker
-from rq.compat import as_text
+from rq.compat import as_text, PY2
 from rq.job import Job, JobStatus
 from rq.registry import StartedJobRegistry
 from rq.suspension import resume, suspend
@@ -43,6 +43,22 @@ class TestWorker(RQTestCase):
         w = Worker(iter(['foo', 'bar']))
         self.assertEqual(w.queues[0].name, 'foo')
         self.assertEqual(w.queues[1].name, 'bar')
+
+        # Also accept byte strings in Python 2
+        if PY2:
+            # With single byte string argument
+            w = Worker(b'foo')
+            self.assertEqual(w.queues[0].name, 'foo')
+
+            # With list of byte strings
+            w = Worker([b'foo', b'bar'])
+            self.assertEqual(w.queues[0].name, 'foo')
+            self.assertEqual(w.queues[1].name, 'bar')
+
+            # With iterable of byte strings
+            w = Worker(iter([b'foo', b'bar']))
+            self.assertEqual(w.queues[0].name, 'foo')
+            self.assertEqual(w.queues[1].name, 'bar')
 
         # With single Queue
         w = Worker(Queue('foo'))


### PR DESCRIPTION
Currently, passing byte strings to the first argument of `Worker()` will cause `TypeError: xxx is not of type <class 'rq.queue.Queue'> or text type`.

However, I think passing byte strings is natural in Python 2. In addition, accepting byte strings make it easy to write Python 2/3 compatible code.
e.g.

```py
Worker(sys.argv[1:])

# Without from __future__ import unicode_literals
Worker(['high', 'normal', 'low'])
```

This PR accept these forms both in Python 2 and 3.