### PR TITLE
docs: Make sample code of workers compatible with Python 3

### DIFF
--- a/docs/workers.md
+++ b/docs/workers.md
@@ -94,7 +94,7 @@ A simple implementation example:
 {% highlight python %}
 #!/usr/bin/env python
 import sys
-from rq import Queue, Connection, Worker
+from rq import Connection, Worker
 
 # Preload libraries
 import library_that_you_want_preloaded
@@ -102,7 +102,7 @@ import library_that_you_want_preloaded
 # Provide queue names to listen to as arguments to this script,
 # similar to rq worker
 with Connection():
-    qs = map(Queue, sys.argv[1:]) or [Queue()]
+    qs = sys.argv[1:] or ['default']
 
     w = Worker(qs)
     w.work()


### PR DESCRIPTION
## Problem

The following worker script in [the worker document](http://python-rq.org/docs/workers/) does not work well in Python 3.

```py
#!/usr/bin/env python
import sys
from rq import Queue, Connection, Worker

# Preload libraries
import library_that_you_want_preloaded

# Provide queue names to listen to as arguments to this script,
# similar to rq worker
with Connection():
    qs = map(Queue, sys.argv[1:]) or [Queue()]

    w = Worker(qs)
    w.work()
```

Running `python3 myworker.py` will cause `redis.exceptions.ResponseError: wrong number of arguments for 'blpop' command`. This is because `map(Queue, [])` in Python 3 returns an iterator which is evaluated as `True`.

## Change

Just passing the list of strings to `Worker()` should fix the problem.

```py
    qs = sys.argv[1:] or ['default']
```
 
This also simplify the worker script.

NOTE: the modified script depends on #650. Without it, the worker script does not work in Python 2.