### PR TITLE
Add ttl argument to decorator

### DIFF
--- a/rq/decorators.py
+++ b/rq/decorators.py
@@ -12,7 +12,7 @@ from .queue import Queue
 
 class job(object):
     def __init__(self, queue, connection=None, timeout=None,
-                 result_ttl=DEFAULT_RESULT_TTL):
+                 result_ttl=DEFAULT_RESULT_TTL, ttl=None):
         """A decorator that adds a ``delay`` method to the decorated function,
         which in turn creates a RQ job when called. Accepts a required
         ``queue`` argument that can be either a ``Queue`` instance or a string
@@ -28,6 +28,7 @@ class job(object):
         self.connection = connection
         self.timeout = timeout
         self.result_ttl = result_ttl
+        self.ttl = ttl
 
     def __call__(self, f):
         @wraps(f)
@@ -38,6 +39,7 @@ class job(object):
                 queue = self.queue
             depends_on = kwargs.pop('depends_on', None)
             return queue.enqueue_call(f, args=args, kwargs=kwargs,
-                                      timeout=self.timeout, result_ttl=self.result_ttl, depends_on=depends_on)
+                                      timeout=self.timeout, result_ttl=self.result_ttl,
+                                      ttl=self.ttl, depends_on=depends_on)
         f.delay = delay
         return f

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -56,6 +56,19 @@ class TestDecorator(RQTestCase):
         result = hello.delay()
         self.assertEqual(result.result_ttl, 10)
 
+    def test_decorator_accepts_ttl_as_argument(self):
+        """Ensure that passing in ttl to the decorator sets the ttl on the job
+        """
+        # Ensure default
+        result = decorated_job.delay(1, 2)
+        self.assertEqual(result.ttl, None)
+
+        @job('default', ttl=30)
+        def hello():
+            return 'Hello'
+        result = hello.delay()
+        self.assertEqual(result.ttl, 30)
+
     def test_decorator_accepts_result_depends_on_as_argument(self):
         """Ensure that passing in depends_on to the decorator sets the
         correct dependency on the job


### PR DESCRIPTION
Add a ttl argument to decorator which will set a TTL for the job.
Default value is None.