### PR TITLE
Ignore lambdas in flake8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,7 @@ requires = redis >= 2.7.0
 
 [wheel]
 universal = 1
+
+[flake8]
+max-line-length=120
+ignore=E731

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -242,14 +242,14 @@ class TestQueue(RQTestCase):
         self.assertEqual(job.func, say_hello)
         self.assertEqual(job.origin, fooq.name)
         self.assertEqual(job.args[0], 'for Foo',
-                          'Foo should be dequeued first.')
+                         'Foo should be dequeued first.')
 
         job, queue = Queue.dequeue_any([fooq, barq], None)
         self.assertEqual(queue, barq)
         self.assertEqual(job.func, say_hello)
         self.assertEqual(job.origin, barq.name)
         self.assertEqual(job.args[0], 'for Bar',
-                          'Bar should be dequeued second.')
+                         'Bar should be dequeued second.')
 
     def test_dequeue_any_ignores_nonexisting_jobs(self):
         """Dequeuing (from any queue) silently ignores non-existing jobs."""
@@ -355,7 +355,6 @@ class TestQueue(RQTestCase):
         # DeferredJobRegistry should also be empty
         self.assertEqual(registry.get_job_ids(), [])
 
-
     def test_enqueue_dependents_on_multiple_queues(self):
         """Enqueueing dependent jobs on multiple queues pushes jobs in the queues
         and removes them from DeferredJobRegistry for each different queue."""
@@ -391,8 +390,6 @@ class TestQueue(RQTestCase):
         # DeferredJobRegistry should also be empty
         self.assertEqual(registry_1.get_job_ids(), [])
         self.assertEqual(registry_2.get_job_ids(), [])
-
-
 
     def test_enqueue_job_with_dependency(self):
         """Jobs are enqueued only when their dependencies are finished."""

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -83,11 +83,11 @@ class TestWorker(RQTestCase):
         fooq, barq = Queue('foo'), Queue('bar')
         w = Worker([fooq, barq])
         self.assertEqual(w.work(burst=True), False,
-                          'Did not expect any work on the queue.')
+                         'Did not expect any work on the queue.')
 
         fooq.enqueue(say_hello, name='Frank')
         self.assertEqual(w.work(burst=True), True,
-                          'Expected at least some work done.')
+                         'Expected at least some work done.')
 
     def test_worker_ttl(self):
         """Worker ttl."""
@@ -103,7 +103,7 @@ class TestWorker(RQTestCase):
         w = Worker([q])
         job = q.enqueue('tests.fixtures.say_hello', name='Frank')
         self.assertEqual(w.work(burst=True), True,
-                          'Expected at least some work done.')
+                         'Expected at least some work done.')
         self.assertEqual(job.result, 'Hi there, Frank!')
 
     def test_job_times(self):
@@ -117,7 +117,7 @@ class TestWorker(RQTestCase):
         self.assertIsNone(job.started_at)
         self.assertIsNone(job.ended_at)
         self.assertEqual(w.work(burst=True), True,
-                          'Expected at least some work done.')
+                         'Expected at least some work done.')
         self.assertEqual(job.result, 'Hi there, Stranger!')
         after = utcnow()
         job.refresh()

--- a/tox.ini
+++ b/tox.ini
@@ -20,4 +20,4 @@ basepython = python2.7
 deps =
     flake8
 commands =
-    flake8 rq tests --max-line-length=120 --ignore=E731
+    flake8 rq tests

--- a/tox.ini
+++ b/tox.ini
@@ -20,4 +20,4 @@ basepython = python2.7
 deps =
     flake8
 commands =
-    flake8 rq tests --max-line-length=120
+    flake8 rq tests --max-line-length=120 --ignore=E731


### PR DESCRIPTION
Sadly the flake8 isn't run in travis (and I don't change that here). But it should still be made green. And the config should be placed in setup.cfg so editors can use the same config for flake8 as tox does.