### PR TITLE
Allow Worker work method to specify the log verbosity

### DIFF
--- a/rq/logutils.py
+++ b/rq/logutils.py
@@ -14,7 +14,7 @@ except ImportError:
 from rq.utils import ColorizingStreamHandler
 
 
-def setup_loghandlers(level='INFO'):
+def setup_loghandlers(level):
     logger = logging.getLogger('rq.worker')
     if not logger.handlers:
         logger.setLevel(level)

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -388,7 +388,7 @@ class Worker(object):
         if before_state:
             self.set_state(before_state)
 
-    def work(self, burst=False):
+    def work(self, burst=False, logging_level=logging.INFO):
         """Starts the work loop.
 
         Pops and performs all jobs on the current list of queues.  When all
@@ -397,7 +397,7 @@ class Worker(object):
 
         The return value indicates whether any jobs were processed.
         """
-        setup_loghandlers()
+        setup_loghandlers(logging_level)
         self._install_signal_handlers()
 
         did_perform_work = False


### PR DESCRIPTION
This is just a patch to expose the logging level on the Worker.work() method.

For instance, it will allow to mute all RQ output if you're using the RQ Worker class.