### PR TITLE
Don't call job.cancel if job has finished

### DIFF
--- a/rq/worker.py
+++ b/rq/worker.py
@@ -605,7 +605,7 @@ class Worker(object):
                     finished_job_registry = FinishedJobRegistry(job.origin, self.connection)
                     finished_job_registry.add(job, result_ttl, pipeline)
 
-                job.cleanup(result_ttl, pipeline=pipeline)
+                job.cleanup(result_ttl, pipeline=pipeline, remove_from_queue=False)
                 started_job_registry.remove(job, pipeline=pipeline)
 
                 pipeline.execute()

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -273,20 +273,26 @@ class TestWorker(RQTestCase):
         q = Queue()
         job = q.enqueue(say_hello, args=('Frank',), result_ttl=10)
         w = Worker([q])
+        self.assertIn(job.get_id().encode('utf-8'), self.testconn.lrange(q.key, 0, -1))
         w.work(burst=True)
         self.assertNotEqual(self.testconn._ttl(job.key), 0)
+        self.assertNotIn(job.get_id().encode('utf-8'), self.testconn.lrange(q.key, 0, -1))
 
         # Job with -1 result_ttl don't expire
         job = q.enqueue(say_hello, args=('Frank',), result_ttl=-1)
         w = Worker([q])
+        self.assertIn(job.get_id().encode('utf-8'), self.testconn.lrange(q.key, 0, -1))
         w.work(burst=True)
         self.assertEqual(self.testconn._ttl(job.key), -1)
+        self.assertNotIn(job.get_id().encode('utf-8'), self.testconn.lrange(q.key, 0, -1))
 
         # Job with result_ttl = 0 gets deleted immediately
         job = q.enqueue(say_hello, args=('Frank',), result_ttl=0)
         w = Worker([q])
+        self.assertIn(job.get_id().encode('utf-8'), self.testconn.lrange(q.key, 0, -1))
         w.work(burst=True)
         self.assertEqual(self.testconn.get(job.key), None)
+        self.assertNotIn(job.get_id().encode('utf-8'), self.testconn.lrange(q.key, 0, -1))
 
     def test_worker_sets_job_status(self):
         """Ensure that worker correctly sets job status."""


### PR DESCRIPTION
This issue #600 migrate `job.cancel()` to `job.delete()` .

When enqueue a job with `result_ttl=0`, after this job is executed, `job_status` is not updated and the `job.cleanup(result_ttl, pipeline=pipeline)` will be called immediately. In `job.cleanup`, `job.cancel()` will be called to remove itself from its `origin queue`, however the job object has already been poped from the `origin queue`.

A redis `lrem ` is used in  `job.cancel()`, this command is O(N) in time complexity and will be very slow if have millions of jobs in the queue. What's more calling `job.cancel()` with a finished job is meaningless.