### PR TITLE
Store the job class information in the queue, closes issue #568.

### DIFF
--- a/rq/job.py
+++ b/rq/job.py
@@ -296,7 +296,7 @@ class Job(object):
         if len(obj) == 0:
             raise NoSuchJobError('No such job: {0}'.format(key))
 
-        job_cls = unpickle(obj['cls'])
+        job_cls = unpickle(obj.get('cls')) if obj.get('cls') else Job
         job = job_cls(id, connection=connection)
         job.refresh()
         return job

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -352,7 +352,7 @@ class Queue(object):
             if job_id is None:
                 return None
             try:
-                job = self.job_class.fetch(job_id, connection=self.connection)
+                job = Job.fetch(job_id, connection=self.connection)
             except NoSuchJobError as e:
                 # Silently pass on jobs that don't exist (anymore),
                 continue
@@ -384,7 +384,7 @@ class Queue(object):
             queue_key, job_id = map(as_text, result)
             queue = cls.from_queue_key(queue_key, connection=connection)
             try:
-                job = cls.job_class.fetch(job_id, connection=connection)
+                job = Job.fetch(job_id, connection=connection)
             except NoSuchJobError:
                 # Silently pass on jobs that don't exist (anymore),
                 # and continue in the look

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -156,6 +156,8 @@ class TestJob(RQTestCase):
                            "(S'tests.fixtures.some_calculation'\nN(I3\nI4\nt(dp1\nS'z'\nI2\nstp2\n.")
         self.testconn.hset('rq:job:some_id', 'created_at',
                            '2012-02-07T22:13:24Z')
+        self.testconn.hset('rq:job:some_id', 'cls',
+                           dumps(Job))
 
         # Fetch returns a job
         job = Job.fetch('some_id')
@@ -186,7 +188,7 @@ class TestJob(RQTestCase):
         # ... and no other keys are stored
         self.assertEqual(
             sorted(self.testconn.hkeys(job.key)),
-            [b'created_at', b'data', b'description'])
+            [b'cls', b'created_at', b'data', b'description'])
 
     def test_persistence_of_parent_job(self):
         """Storing jobs with parent job, either instance or key."""

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -168,6 +168,24 @@ class TestJob(RQTestCase):
         self.assertEqual(job.kwargs, dict(z=2))
         self.assertEqual(job.created_at, datetime(2012, 2, 7, 22, 13, 24))
 
+    def test_fetch_defaults_to_Job_class_when_cls_is_missing(self):
+        """Fetching jobs."""
+        # Prepare test
+        self.testconn.hset('rq:job:some_id', 'data',
+                           "(S'tests.fixtures.some_calculation'\nN(I3\nI4\nt(dp1\nS'z'\nI2\nstp2\n.")
+        self.testconn.hset('rq:job:some_id', 'created_at',
+                           '2012-02-07T22:13:24Z')
+        # don't set 'cls', as compared to test_fetch()
+
+        # Fetch returns a job
+        job = Job.fetch('some_id')
+        self.assertEqual(job.id, 'some_id')
+        self.assertEqual(job.func_name, 'tests.fixtures.some_calculation')
+        self.assertIsNone(job.instance)
+        self.assertEqual(job.args, (3, 4))
+        self.assertEqual(job.kwargs, dict(z=2))
+        self.assertEqual(job.created_at, datetime(2012, 2, 7, 22, 13, 24))
+
     def test_persistence_of_empty_jobs(self):  # noqa
         """Storing empty jobs."""
         job = Job()

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -275,7 +275,7 @@ class TestQueue(RQTestCase):
 
         class OtherCustomJob(Job):
             @classmethod
-            def fetch(cls,id, connection=None):
+            def fetch(cls, id, connection=None):
                 return self.__init__(id, connection)
 
         q = Queue('high', job_class=OtherCustomJob)


### PR DESCRIPTION
Pickle the class object of the Job instance and include it when
serializing the Job instance for storage in the Redis queue.