### PR TITLE
Fix issue 702

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,6 @@ install:
   - pip install coveralls
   #- pip install pytest  # installed by Travis by default already
 script:
-  - RUN_SLOW_TESTS_TOO=1 py.test --cov rq --durations=10
+  - RUN_SLOW_TESTS_TOO=1 py.test --cov rq --durations=5
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,6 @@ install:
   - pip install coveralls
   #- pip install pytest  # installed by Travis by default already
 script:
-  - RUN_SLOW_TESTS_TOO=1 py.test --cov rq --durations=5
+  - RUN_SLOW_TESTS_TOO=1 py.test --cov rq --durations=10
 after_success:
   - coveralls

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -538,9 +538,19 @@ class Worker(object):
                                 pipeline.execute()
                             except Exception:
                                 pass
-                            self.move_to_failed_queue_unhandled(
+
+                            #Unhandled failure: move the job to the failed queue
+                            self.log.warning(
+                                'Moving job to {0!r} queue'.format(
+                                    self.failed_queue.name
+                                )
+                            )
+                            self.failed_queue.quarantine(
                                 job,
-                                "Work-horse proccess was terminated unexpectedly"
+                                exc_info=(
+                                    "Work-horse proccess "
+                                    "was terminated unexpectedly"
+                                )
                             )
                 break
             except OSError as e:
@@ -731,11 +741,6 @@ class Worker(object):
         exc_string = ''.join(traceback.format_exception(*exc_info))
         self.log.warning('Moving job to {0!r} queue'.format(self.failed_queue.name))
         self.failed_queue.quarantine(job, exc_info=exc_string)
-
-    def move_to_failed_queue_unhandled(self, job, message):
-        """Unhandled failure default handler: move the job to the failed queue."""
-        self.log.warning('Moving job to {0!r} queue'.format(self.failed_queue.name))
-        self.failed_queue.quarantine(job, exc_info=message)
 
     def push_exc_handler(self, handler_func):
         """Pushes an exception handler onto the exc handler stack."""

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -503,13 +503,9 @@ class Worker(object):
         self.log.debug('Sent heartbeat to prevent worker timeout. '
                        'Next one should arrive within {0} seconds.'.format(timeout))
 
-    def execute_job(self, job, queue):
+    def fork_work_horse(self, job, queue):
         """Spawns a work horse to perform the actual work and passes it a job.
-        The worker will wait for the work horse and make sure it executes
-        within the given timeout bounds, or will end the work horse with
-        SIGALRM.
         """
-        self.set_state('busy')
         child_pid = os.fork()
         os.environ['RQ_WORKER_ID'] = self.name
         os.environ['RQ_JOB_ID'] = job.id
@@ -518,20 +514,36 @@ class Worker(object):
         else:
             self._horse_pid = child_pid
             self.procline('Forked {0} at {1}'.format(child_pid, time.time()))
-            while True:
-                try:
-                    os.waitpid(child_pid, 0)
-                    self.set_state('idle')
-                    break
-                except OSError as e:
-                    # In case we encountered an OSError due to EINTR (which is
-                    # caused by a SIGINT or SIGTERM signal during
-                    # os.waitpid()), we simply ignore it and enter the next
-                    # iteration of the loop, waiting for the child to end.  In
-                    # any other case, this is some other unexpected OS error,
-                    # which we don't want to catch, so we re-raise those ones.
-                    if e.errno != errno.EINTR:
-                        raise
+
+    def monitor_work_horse(self, job):
+        """The worker will wait for the work horse and make sure it executes
+        within the given timeout bounds, or will end the work horse with
+        SIGALRM.
+        """
+        while True:
+            try:
+                _, ret_val = os.waitpid(self._horse_pid, 0)
+                break
+            except OSError as e:
+                # In case we encountered an OSError due to EINTR (which is
+                # caused by a SIGINT or SIGTERM signal during
+                # os.waitpid()), we simply ignore it and enter the next
+                # iteration of the loop, waiting for the child to end.  In
+                # any other case, this is some other unexpected OS error,
+                # which we don't want to catch, so we re-raise those ones.
+                if e.errno != errno.EINTR:
+                    raise
+
+    def execute_job(self, job, queue):
+        """Spawns a work horse to perform the actual work and passes it a job.
+        The worker will wait for the work horse and make sure it executes
+        within the given timeout bounds, or will end the work horse with
+        SIGALRM.
+        """
+        self.set_state('busy')
+        self.fork_work_horse(job, queue)
+        self.monitor_work_horse(job)
+        self.set_state('idle')
 
     def main_work_horse(self, job, queue):
         """This is the entry point of the newly spawned work horse."""

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -530,7 +530,7 @@ class Worker(object):
                         break
                     if job_status not in [JobStatus.FINISHED, JobStatus.FAILED]:
                         with self.connection._pipeline() as pipeline:
-                            self.handle_current_job_failure(
+                            self.handle_job_failure(
                                 job=job,
                                 pipeline=pipeline
                             )
@@ -611,7 +611,7 @@ class Worker(object):
         msg = 'Processing {0} from {1} since {2}'
         self.procline(msg.format(job.func_name, job.origin, time.time()))
 
-    def handle_current_job_failure(
+    def handle_job_failure(
         self,
         job,
         started_job_registry=None,
@@ -672,7 +672,7 @@ class Worker(object):
                 pipeline.execute()
 
             except Exception:
-                self.handle_current_job_failure(
+                self.handle_job_failure(
                     job=job,
                     started_job_registry=started_job_registry,
                     pipeline=pipeline

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -516,9 +516,9 @@ class Worker(object):
             self.procline('Forked {0} at {1}'.format(child_pid, time.time()))
 
     def monitor_work_horse(self, job):
-        """The worker will wait for the work horse and make sure it executes
-        within the given timeout bounds, or will end the work horse with
-        SIGALRM.
+        """The worker will monitor the work horse and make sure that it
+        either executes successfully or the status of the job is set to
+        failed
         """
         while True:
             try:

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -523,7 +523,7 @@ class Worker(object):
         while True:
             try:
                 _, ret_val = os.waitpid(self._horse_pid, 0)
-                if not (ret_val == os.EX_OK):
+                if ret_val != os.EX_OK:
                     job_status = job.get_status()
                     if job_status is None:
                         # Job completed and its ttl has expired

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -587,7 +587,7 @@ class TimeoutTestCase:
     def setUp(self):
         # we want tests to fail if signal are ignored and the work remain
         # running, so set a signal to kill them after X seconds
-        self.killtimeout = 10
+        self.killtimeout = 20
         signal.signal(signal.SIGALRM, self._timeout)
         signal.alarm(self.killtimeout)
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -587,7 +587,7 @@ class TimeoutTestCase:
     def setUp(self):
         # we want tests to fail if signal are ignored and the work remain
         # running, so set a signal to kill them after X seconds
-        self.killtimeout = 20
+        self.killtimeout = 10
         signal.signal(signal.SIGALRM, self._timeout)
         signal.alarm(self.killtimeout)
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -14,7 +14,8 @@ import subprocess
 from tests import RQTestCase, slow
 from tests.fixtures import (create_file, create_file_after_timeout,
                             div_by_zero, do_nothing, say_hello, say_pid,
-                            run_dummy_heroku_worker, access_self)
+                            run_dummy_heroku_worker, access_self,
+                            long_running_job)
 from tests.helpers import strip_microseconds
 
 from rq import (get_failed_queue, Queue, SimpleWorker, Worker,
@@ -577,6 +578,9 @@ def kill_worker(pid, double_kill):
         time.sleep(0.5)
         os.kill(pid, signal.SIGTERM)
 
+def kill_work_horse(pid):
+    os.kill(pid, signal.SIGKILL)
+
 
 class TimeoutTestCase:
     def setUp(self):
@@ -649,6 +653,35 @@ class WorkerShutdownTestCase(TimeoutTestCase, RQTestCase):
         self.assertIsNotNone(shutdown_requested_date)
         self.assertEqual(type(shutdown_requested_date).__name__, 'datetime')
 
+    @slow
+    def test_work_horse_death_sets_job_failed(self):
+        """worker with an ongoing job whose work horse dies unexpectadly should
+        set the job's status either to FINISHED or FAILED
+        """
+        fooq = Queue('foo')
+        failed_q = get_failed_queue()
+        self.assertEqual(failed_q.count, 0)
+        self.assertEqual(fooq.count, 0)
+        w = Worker(fooq)
+        registry = StartedJobRegistry(connection=self.testconn)
+        sentinel_file = '/tmp/.rq_sentinel_work_horse_death'
+        if os.path.exists(sentinel_file):
+            os.remove(sentinel_file)
+        fooq.enqueue(create_file_after_timeout, sentinel_file, 100)
+        job, queue = w.dequeue_job_and_maintain_ttl(5)
+        w.fork_work_horse(job, queue)
+        p = Process(target=kill_work_horse, args=(w._horse_pid,))
+        p.start()
+        p.join(1)
+        w.monitor_work_horse(job)
+        job_status = job.get_status()
+        if os.path.exists(sentinel_file):
+            self.assertEqual(job_status, JobStatus.FINISHED)
+            os.remove(sentinel_file)
+        else:
+            self.assertEqual(job_status, JobStatus.FAILED)
+            self.assertEqual(failed_q.count, 1)
+            self.assertEqual(fooq.count, 0)
 
 def schedule_access_self():
     q = Queue('default', connection=get_current_connection())

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -656,8 +656,8 @@ class WorkerShutdownTestCase(TimeoutTestCase, RQTestCase):
 
     @slow
     def test_work_horse_death_sets_job_failed(self):
-        """worker with an ongoing job whose work horse dies unexpectadly should
-        set the job's status either to FINISHED or FAILED
+        """worker with an ongoing job whose work horse dies unexpectadly (before
+        completing the job) should set the job's status to FAILED
         """
         fooq = Queue('foo')
         failed_q = get_failed_queue()
@@ -675,13 +675,9 @@ class WorkerShutdownTestCase(TimeoutTestCase, RQTestCase):
         w.monitor_work_horse(job)
         job_status = job.get_status()
         p.join(1)
-        if os.path.exists(sentinel_file):
-            self.assertEqual(job_status, JobStatus.FINISHED)
-            os.remove(sentinel_file)
-        else:
-            self.assertEqual(job_status, JobStatus.FAILED)
-            self.assertEqual(failed_q.count, 1)
-            self.assertEqual(fooq.count, 0)
+        self.assertEqual(job_status, JobStatus.FAILED)
+        self.assertEqual(failed_q.count, 1)
+        self.assertEqual(fooq.count, 0)
 
 def schedule_access_self():
     q = Queue('default', connection=get_current_connection())


### PR DESCRIPTION
In order to solve issue 702 we have to check whether a work-horse terminated unexpectedly (by inspecting the exit code of the work-horse process). If it exited unexpectedly we check if the job has either been marked as finished, failed or other valid states. If it's not in any valid state we mark it as failed and move it to the failed queue. Since the process was terminated unexpectedly (think OOM) we do not have any exception context and we can't run any custom exception handlers.
    
There is still a chance that the job will finish successfully but the work-horse process will be killed before the job is marked as finished and we will erroneously mark it as failed. The users should take care to write idempotent jobs.