### PR TITLE
Improved fix for python 3 frame handling and tests

### DIFF
--- a/rq/worker.py
+++ b/rq/worker.py
@@ -16,6 +16,7 @@ from datetime import timedelta
 
 from rq.compat import as_text, string_types, text_type
 
+from .compat import PY2
 from .connections import get_current_connection, push_connection, pop_connection
 from .defaults import DEFAULT_RESULT_TTL, DEFAULT_WORKER_TTL
 from .exceptions import DequeueTimeout, ShutDownImminentException
@@ -800,7 +801,7 @@ class HerokuWorker(Worker):
     imminent_shutdown_delay = 6
 
     frame_properties = ['f_code', 'f_lasti', 'f_lineno', 'f_locals', 'f_trace']
-    if sys.version_info[:2] < (3, 0):
+    if PY2:
         frame_properties.extend(
             ['f_exc_traceback', 'f_exc_type', 'f_exc_value', 'f_restricted']
         )

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -8,6 +8,7 @@ from __future__ import (absolute_import, division, print_function,
 
 import os
 import time
+import sys
 
 from rq import Connection, get_current_job, get_current_connection, Queue
 from rq.decorators import job
@@ -112,6 +113,8 @@ def run_dummy_heroku_worker(sandbox, _imminent_shutdown_delay):
     :param sandbox: directory to create files in
     :param _imminent_shutdown_delay: delay to use for HerokuWorker
     """
+    sys.stderr = open(os.path.join(sandbox, 'stderr.log'), 'w')
+
     class TestHerokuWorker(HerokuWorker):
         imminent_shutdown_delay = _imminent_shutdown_delay
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -14,8 +14,7 @@ import subprocess
 from tests import RQTestCase, slow
 from tests.fixtures import (create_file, create_file_after_timeout,
                             div_by_zero, do_nothing, say_hello, say_pid,
-                            run_dummy_heroku_worker, access_self,
-                            long_running_job)
+                            run_dummy_heroku_worker, access_self)
 from tests.helpers import strip_microseconds
 
 from rq import (get_failed_queue, Queue, SimpleWorker, Worker,
@@ -733,6 +732,10 @@ class HerokuWorkerShutdownTestCase(TimeoutTestCase, RQTestCase):
         self.assertEqual(p.exitcode, 1)
         self.assertTrue(os.path.exists(os.path.join(self.sandbox, 'started')))
         self.assertFalse(os.path.exists(os.path.join(self.sandbox, 'finished')))
+        with open(os.path.join(self.sandbox, 'stderr.log')) as f:
+            stderr = f.read().strip('\n')
+            err = 'ShutDownImminentException: shut down imminent (signal: SIGRTMIN)'
+            self.assertTrue(stderr.endswith(err), stderr)
 
     @slow
     def test_1_sec_shutdown(self):
@@ -749,6 +752,10 @@ class HerokuWorkerShutdownTestCase(TimeoutTestCase, RQTestCase):
 
         self.assertTrue(os.path.exists(os.path.join(self.sandbox, 'started')))
         self.assertFalse(os.path.exists(os.path.join(self.sandbox, 'finished')))
+        with open(os.path.join(self.sandbox, 'stderr.log')) as f:
+            stderr = f.read().strip('\n')
+            err = 'ShutDownImminentException: shut down imminent (signal: SIGALRM)'
+            self.assertTrue(stderr.endswith(err), stderr)
 
     @slow
     def test_shutdown_double_sigrtmin(self):
@@ -766,6 +773,10 @@ class HerokuWorkerShutdownTestCase(TimeoutTestCase, RQTestCase):
 
         self.assertTrue(os.path.exists(os.path.join(self.sandbox, 'started')))
         self.assertFalse(os.path.exists(os.path.join(self.sandbox, 'finished')))
+        with open(os.path.join(self.sandbox, 'stderr.log')) as f:
+            stderr = f.read().strip('\n')
+            err = 'ShutDownImminentException: shut down imminent (signal: SIGRTMIN)'
+            self.assertTrue(stderr.endswith(err), stderr)
 
     def test_handle_shutdown_request(self):
         """Mutate HerokuWorker so _horse_pid refers to an artificial process


### PR DESCRIPTION
Uses compat for PY2 check and add tests which check the error raised by signals is correct.

Fixes #715, improves #727