### PR TITLE
Windows console fix

### DIFF
--- a/rq/utils.py
+++ b/rq/utils.py
@@ -15,11 +15,18 @@ import logging
 import sys
 from collections import Iterable
 
+try:
+    import colorama
+except ImportError:
+    colorama = None
+
 from .compat import as_text, is_python_version, string_types
 
 
 class _Colorizer(object):
     def __init__(self):
+        colorama and colorama.init()
+        
         esc = "\x1b["
 
         self.codes = {}
@@ -53,6 +60,7 @@ class _Colorizer(object):
 
         if hasattr(sys.stdout, "isatty"):
             self.notty = not sys.stdout.isatty()
+            self.notty = sys.platform == 'win32' and not colorama
         else:
             self.notty = True
 


### PR DESCRIPTION
On Windows console, Worker outputs something like this:

```
*** Listening on [32mdefault[39;49;00m...
```

This patch disables ANSI on Windows if `colorama` package is not installed.
If `colorama` is installed, Windows support [is initialized](https://github.com/tartley/colorama#usage).