### PR TITLE
Raise an exception if a given dependency does not exist

### DIFF
--- a/rq/exceptions.py
+++ b/rq/exceptions.py
@@ -7,6 +7,10 @@ class NoSuchJobError(Exception):
     pass
 
 
+class InvalidJobDependency(Exception):
+    pass
+
+
 class InvalidJobOperationError(Exception):
     pass
 

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -9,8 +9,8 @@ from redis import WatchError
 from .compat import as_text, string_types, total_ordering
 from .connections import resolve_connection
 from .defaults import DEFAULT_RESULT_TTL
-from .exceptions import (DequeueTimeout, InvalidJobOperationError,
-                         NoSuchJobError, UnpickleError)
+from .exceptions import (DequeueTimeout, InvalidJobDependency,
+                         InvalidJobOperationError, NoSuchJobError, UnpickleError)
 from .job import Job, JobStatus
 from .utils import import_attribute, utcnow
 
@@ -202,6 +202,13 @@ class Queue(object):
                 while True:
                     try:
                         pipe.watch(depends_on.key)
+
+                        # If the dependency does not exist, we raise an
+                        # exception. So the caller is able to avoid an orphaned
+                        # job.
+                        if not self.job_class.exists(depends_on.id):
+                            raise InvalidJobDependency('Job {0} does not exist'.format(depends_on.id))
+
                         if depends_on.get_status() != JobStatus.FINISHED:
                             pipe.multi()
                             job.set_status(JobStatus.DEFERRED)


### PR DESCRIPTION
Adapted some tests to the change: the dependency has to be saved first.

This is a replacement for the PR #743 (see https://github.com/nvie/rq/pull/743#issuecomment-241607859).