### PR TITLE
fix issue with FailedQueue object could not fetch failed jobs.

### DIFF
--- a/rq/queue.py
+++ b/rq/queue.py
@@ -106,13 +106,12 @@ class Queue(object):
         return self.count == 0
 
     def fetch_job(self, job_id):
+        if job_id not in self.job_ids:
+            return
         try:
-            job = self.job_class.fetch(job_id, connection=self.connection)
+            return self.job_class.fetch(job_id, connection=self.connection)
         except NoSuchJobError:
             self.remove(job_id)
-        else:
-            if job.origin == self.name:
-                return job
 
     def get_job_ids(self, offset=0, length=-1):
         """Returns a slice of job IDs in the queue."""


### PR DESCRIPTION
Unfortunately `FailedQueue` object is unable to fetch failed jobs.

[django-rq](https://github.com/ui/django-rq) rely on failed queue