### PR TITLE
Fix get job on failed queue

### DIFF
--- a/rq/queue.py
+++ b/rq/queue.py
@@ -111,7 +111,7 @@ class Queue(object):
         except NoSuchJobError:
             self.remove(job_id)
         else:
-            if self == get_failed_queue(connection=self.connection) or job.origin == self.name:
+            if job.origin == self.name or (job.is_failed and self == get_failed_queue(connection=self.connection)):
                 return job
 
     def get_job_ids(self, offset=0, length=-1):

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -111,7 +111,7 @@ class Queue(object):
         except NoSuchJobError:
             self.remove(job_id)
         else:
-            if job.origin == self.name:
+            if self == get_failed_queue(connection=self.connection) or job.origin == self.name:
                 return job
 
     def get_job_ids(self, offset=0, length=-1):


### PR DESCRIPTION
#733 broke getting job on the failed queue, making it impossible to display detail in rq-dashboard or django-rq, this PR add another check on the requesting queue.