### PR TITLE
Use HTTPTransport transport so sentry reporting works by default

### DIFF
--- a/rq/cli/cli.py
+++ b/rq/cli/cli.py
@@ -199,8 +199,9 @@ def worker(url, config, burst, name, worker_class, job_class, queue_class, conne
         # Should we configure Sentry?
         if sentry_dsn:
             from raven import Client
+            from raven.transport.http import HTTPTransport
             from rq.contrib.sentry import register_sentry
-            client = Client(sentry_dsn)
+            client = Client(sentry_dsn, transport=HTTPTransport)
             register_sentry(client, w)
 
         w.work(burst=burst)


### PR DESCRIPTION
The Threaded transport (default) is not reliable, breaking the error reporting. This PR switch it to the HTTPTransport bringing a working out-of-the-box experience.
I can also add a `--sentry-transport-class` option to the CLI if you want/prefer.