### PR TITLE
Don't run lrem directly if we have a pipeline

### DIFF
--- a/rq/queue.py
+++ b/rq/queue.py
@@ -150,6 +150,7 @@ class Queue(object):
 
         if pipeline is not None:
             pipeline.lrem(self.key, 1, job_id)
+            return
 
         return self.connection._lrem(self.key, 1, job_id)
 


### PR DESCRIPTION
Not sure if this is correct, but I was looking through the code and noticed that if a pipeline is passed to `Queue.cancel` we add an `lrem` call to the pipeline and then also call `lrem` immediately on the connection.  I think we just want to add it to the pipeline in that case?