### PR TITLE
fix: set HTTP transport as default for sentry

### DIFF
--- a/rq/cli/cli.py
+++ b/rq/cli/cli.py
@@ -199,8 +199,9 @@ def worker(url, config, burst, name, worker_class, job_class, queue_class, conne
         # Should we configure Sentry?
         if sentry_dsn:
             from raven import Client
+            from raven.transport.http import HTTPTransport
             from rq.contrib.sentry import register_sentry
-            client = Client(sentry_dsn)
+            client = Client(sentry_dsn, transport=HTTPTransport)
             register_sentry(client, w)
 
         w.work(burst=burst)


### PR DESCRIPTION
Related to nvie/rq#777

AFAIK, nobody would like to use the default async transport as it won't work. Maybe we can add a parameter `--sentry-transport-class`.

(and thanks for rq!)