### PR TITLE
Trigger a refresh after job execution

### DIFF
--- a/rq/queue.py
+++ b/rq/queue.py
@@ -229,7 +229,7 @@ class Queue(object):
         if not self._async:
             job.perform()
             job.set_status(JobStatus.FINISHED)
-            job.save()
+            job.save(include_meta=False)
             job.cleanup(DEFAULT_RESULT_TTL)
 
         return job
@@ -474,7 +474,7 @@ class FailedQueue(Queue):
 
             job.ended_at = utcnow()
             job.exc_info = exc_info
-            job.save(pipeline=pipeline)
+            job.save(pipeline=pipeline, include_meta=False)
 
             self.push_job_id(job.id, pipeline=pipeline)
             pipeline.execute()

--- a/rq/registry.py
+++ b/rq/registry.py
@@ -89,7 +89,7 @@ class StartedJobRegistry(BaseRegistry):
                     try:
                         job = Job.fetch(job_id, connection=self.connection)
                         job.set_status(JobStatus.FAILED)
-                        job.save(pipeline=pipeline)
+                        job.save(pipeline=pipeline, include_meta=False)
                         failed_queue.push_job_id(job_id, pipeline=pipeline)
                     except NoSuchJobError:
                         pass

--- a/rq/worker.py
+++ b/rq/worker.py
@@ -705,6 +705,7 @@ class Worker(object):
         try:
             with self.death_penalty_class(job.timeout or self.queue_class.DEFAULT_TIMEOUT):
                 rv = job.perform()
+            job.refresh()
 
             job.ended_at = utcnow()
 
@@ -718,6 +719,7 @@ class Worker(object):
                 started_job_registry=started_job_registry
             )
         except Exception:
+            job.refresh()
             self.handle_job_failure(
                 job=job,
                 started_job_registry=started_job_registry

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -67,6 +67,13 @@ def modify_self(meta):
     j.save()
 
 
+def modify_self_and_error(meta):
+    j = get_current_job()
+    j.meta.update(meta)
+    j.save()
+    return 1 / 0
+
+
 def echo(*args, **kwargs):
     return (args, kwargs)
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -61,6 +61,12 @@ def access_self():
     assert get_current_job() is not None
 
 
+def modify_self(meta):
+    j = get_current_job()
+    j.meta.update(meta)
+    j.save()
+
+
 def echo(*args, **kwargs):
     return (args, kwargs)
 


### PR DESCRIPTION
* Prevents clobbering of user-supplied metadata
  modified during the job execution
* Allows the "Storing arbitrary data on jobs" example at http://python-rq.org/docs/jobs/ to actually persist.