### PR TITLE
Closes issue #784: Avoid losing meta job information after successful finish.

### DIFF
--- a/rq/worker.py
+++ b/rq/worker.py
@@ -669,6 +669,8 @@ class Worker(object):
 
                     result_ttl = job.get_result_ttl(self.default_result_ttl)
                     if result_ttl != 0:
+                        # See issue #784. Avoid losing job information.
+                        job.refresh()
                         job.set_status(JobStatus.FINISHED, pipeline=pipeline)
                         job.save(pipeline=pipeline)
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -27,6 +27,13 @@ def say_hello(name=None):
     return 'Hi there, %s!' % (name,)
 
 
+def update_meta():
+    job = get_current_job()
+    job.meta['progress'] = 'Some progress was made'
+    job.save()
+    return 'update_meta was successful'
+
+
 def do_nothing():
     """The best job in the world."""
     pass

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -122,6 +122,20 @@ class TestWorker(RQTestCase):
         )
         self.assertEqual(job.result, 'Hi there, Frank!')
 
+    def test_work_meta_preserved(self):
+        """Issue #784: Work meta information not lost"""
+        q = Queue('foo')
+        w = Worker([q])
+        meta = {'progress': 'Queued'}
+        job = q.enqueue('tests.fixtures.update_meta', meta=meta)
+        self.assertEqual(
+            w.work(burst=True), True,
+            'Expected at least some work done.'
+        )
+        job.refresh()
+        self.assertEqual(job.result, 'update_meta was successful')
+        self.assertEqual(job.meta['progress'], 'Some progress was made')
+
     def test_job_times(self):
         """job times are set correctly."""
         q = Queue('foo')


### PR DESCRIPTION
As described in the issue.