### PR TITLE
CLI: RQ_CONFIG environment variable

### DIFF
--- a/rq/cli/cli.py
+++ b/rq/cli/cli.py
@@ -33,7 +33,7 @@ click.disable_unicode_literals_warning = True
 url_option = click.option('--url', '-u', envvar='RQ_REDIS_URL',
                           help='URL describing Redis connection details.')
 
-config_option = click.option('--config', '-c',
+config_option = click.option('--config', '-c', envvar='RQ_CONFIG',
                              help='Module containing RQ settings.')
 
 


### PR DESCRIPTION
Add the `RQ_CONFIG` environment variable as an alias for `-c`/`--config`.

```shell
$ echo 'print("hello")' > my_config_module.py
$ env RQ_CONFIG=my_config_module rq worker
hello
13:37:00 RQ worker '...' started, ...
```