### PR TITLE
Make `Queue.enqueue_job()` execute job immediately if `async=False`

### DIFF
--- a/rq/queue.py
+++ b/rq/queue.py
@@ -231,9 +231,6 @@ class Queue(object):
 
         job = self.enqueue_job(job, at_front=at_front)
 
-        if not self._async:
-            job = self.run_job(job)
-
         return job
 
     def run_job(self, job):
@@ -305,6 +302,9 @@ class Queue(object):
 
         if pipeline is None:
             pipe.execute()
+
+        if not self._async:
+            job = self.run_job(job)
 
         return job
 

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -322,6 +322,13 @@ class TestJob(RQTestCase):
         self.assertEqual(job.result, 'Hi there, Stranger!')
         self.assertEqual(job.get_status(), JobStatus.FINISHED)
 
+    def test_enqueue_job_async_status_finished(self):
+        queue = Queue(async=False)
+        job = Job.create(func=fixtures.say_hello)
+        job = queue.enqueue_job(job)
+        self.assertEqual(job.result, 'Hi there, Stranger!')
+        self.assertEqual(job.get_status(), JobStatus.FINISHED)
+
     def test_get_result_ttl(self):
         """Getting job result TTL."""
         job_result_ttl = 1


### PR DESCRIPTION
Currently, the job is being performed inside `enqueue_call()`, which
means that `async=False` has no effect if `enqueue_job()` is called
directly. This commit fixes that.