### PR TITLE
Minor spelling mistake

### DIFF
--- a/rq/worker.py
+++ b/rq/worker.py
@@ -562,7 +562,7 @@ class Worker(object):
                         self.failed_queue.quarantine(
                             job,
                             exc_info=(
-                                "Work-horse proccess "
+                                "Work-horse process "
                                 "was terminated unexpectedly"
                             )
                         )


### PR DESCRIPTION
Minor spelling update of `proccess` to `process`