### PR TITLE
updating the sys.path for import of a custom class

### DIFF
--- a/rq/cli/cli.py
+++ b/rq/cli/cli.py
@@ -134,7 +134,7 @@ def requeue(cli_config, all, job_class, job_ids, **options):
 
 
 @main.command()
-@click.option('--path', '-P', default='.', help='Specify the import path.')
+@click.option('--path', '-P', default='.', help='Specify the import path.', multiple=True)
 @click.option('--interval', '-i', type=float, help='Updates stats every N seconds (default: don\'t poll)')
 @click.option('--raw', '-r', is_flag=True, help='Print only the raw numbers, no bar charts')
 @click.option('--only-queues', '-Q', is_flag=True, help='Show only queue info')
@@ -142,12 +142,9 @@ def requeue(cli_config, all, job_class, job_ids, **options):
 @click.option('--by-queue', '-R', is_flag=True, help='Shows workers by queue')
 @click.argument('queues', nargs=-1)
 @pass_cli_config
-def info(cli_config, path, interval, raw, only_queues, only_workers, by_queue, queues,
+def info(cli_config, interval, raw, only_queues, only_workers, by_queue, queues,
          **options):
     """RQ command-line monitor."""
-
-    if path:
-        sys.path = path.split(':') + sys.path
 
     if only_queues:
         func = show_queues
@@ -171,7 +168,7 @@ def info(cli_config, path, interval, raw, only_queues, only_workers, by_queue, q
 @main.command()
 @click.option('--burst', '-b', is_flag=True, help='Run in burst mode (quit after all work is done)')
 @click.option('--name', '-n', help='Specify a different name')
-@click.option('--path', '-P', default='.', help='Specify the import path.')
+@click.option('--path', '-P', default='.', help='Specify the import path.', multiple=True)
 @click.option('--results-ttl', type=int, help='Default results timeout to be used')
 @click.option('--worker-ttl', type=int, help='Default worker timeout to be used')
 @click.option('--verbose', '-v', is_flag=True, help='Show more output')
@@ -181,13 +178,10 @@ def info(cli_config, path, interval, raw, only_queues, only_workers, by_queue, q
 @click.option('--pid', help='Write the process ID number to a file at the specified path')
 @click.argument('queues', nargs=-1)
 @pass_cli_config
-def worker(cli_config, burst, name, path, results_ttl,
+def worker(cli_config, burst, name, results_ttl,
            worker_ttl, verbose, quiet, sentry_dsn, exception_handler,
            pid, queues, **options):
     """Starts an RQ worker."""
-
-    if path:
-        sys.path = path.split(':') + sys.path
 
     settings = read_config_file(cli_config.config) if cli_config.config else {}
     # Worker specific default arguments

--- a/rq/cli/helpers.py
+++ b/rq/cli/helpers.py
@@ -226,7 +226,8 @@ class CliConfig(object):
         self.config = config
 
         if path:
-            sys.path = path.split(':') + sys.path
+            for pth in path:
+                sys.path.append(pth)
 
         try:
             self.worker_class = import_attribute(worker_class)

--- a/rq/cli/helpers.py
+++ b/rq/cli/helpers.py
@@ -3,6 +3,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import importlib
+import sys
 import time
 from functools import partial
 
@@ -219,10 +220,13 @@ class CliConfig(object):
     """A helper class to be used with click commands, to handle shared options"""
     def __init__(self, url=None, config=None, worker_class=DEFAULT_WORKER_CLASS,
                  job_class=DEFAULT_JOB_CLASS, queue_class=DEFAULT_QUEUE_CLASS,
-                 connection_class=DEFAULT_CONNECTION_CLASS, *args, **kwargs):
+                 connection_class=DEFAULT_CONNECTION_CLASS, path=None, *args, **kwargs):
         self._connection = None
         self.url = url
         self.config = config
+
+        if path:
+            sys.path = path.split(':') + sys.path
 
         try:
             self.worker_class = import_attribute(worker_class)

--- a/rq/cli/helpers.py
+++ b/rq/cli/helpers.py
@@ -30,7 +30,11 @@ def read_config_file(module):
 
 
 def get_redis_from_config(settings, connection_class=StrictRedis):
-    """Returns a StrictRedis instance from a dictionary of settings."""
+    """Returns a StrictRedis instance from a dictionary of settings.
+       To use redis sentinel, you must specify a dictionary in the configuration file.
+       Example of a dictionary with keys without values:
+       SENTINEL: {'INSTANCES':, 'SOCKET_TIMEOUT':, 'PASSWORD':,'DB':, 'MASTER_NAME':}
+    """
     if settings.get('REDIS_URL') is not None:
         return connection_class.from_url(settings['REDIS_URL'])
 

--- a/rq/cli/helpers.py
+++ b/rq/cli/helpers.py
@@ -38,8 +38,9 @@ def get_redis_from_config(settings, connection_class=StrictRedis):
         instances = settings['SENTINEL'].get('INSTANCES', [('localhost', 26379)])
         socket_timeout = settings['SENTINEL'].get('SOCKET_TIMEOUT', None)
         password = settings['SENTINEL'].get('PASSWORD', None)
+        db = settings['SENTINEL'].get('DB', 0)
         master_name = settings['SENTINEL'].get('MASTER_NAME', 'mymaster')
-        sn = Sentinel(instances, socket_timeout=socket_timeout, password=password)
+        sn = Sentinel(instances, socket_timeout=socket_timeout, password=password, db=db)
         return sn.master_for(master_name)
 
     kwargs = {

--- a/rq/cli/helpers.py
+++ b/rq/cli/helpers.py
@@ -9,6 +9,7 @@ from functools import partial
 import click
 import redis
 from redis import StrictRedis
+from redis.sentinel import Sentinel
 from rq.defaults import (DEFAULT_CONNECTION_CLASS, DEFAULT_JOB_CLASS,
                          DEFAULT_QUEUE_CLASS, DEFAULT_WORKER_CLASS)
 from rq.logutils import setup_loghandlers
@@ -32,6 +33,14 @@ def get_redis_from_config(settings, connection_class=StrictRedis):
     """Returns a StrictRedis instance from a dictionary of settings."""
     if settings.get('REDIS_URL') is not None:
         return connection_class.from_url(settings['REDIS_URL'])
+
+    elif settings.get('SENTINEL') is not None:
+        instances = settings['SENTINEL'].get('INSTANCES', [('localhost', 26379)])
+        socket_timeout = settings['SENTINEL'].get('SOCKET_TIMEOUT', None)
+        password = settings['SENTINEL'].get('PASSWORD', None)
+        master_name = settings['SENTINEL'].get('MASTER_NAME', 'mymaster')
+        sn = Sentinel(instances, socket_timeout=socket_timeout, password=password)
+        return sn.master_for(master_name)
 
     kwargs = {
         'host': settings.get('REDIS_HOST', 'localhost'),


### PR DESCRIPTION
Without updating the sys.path, import of a custom class will not work

example:
rqworker -c config -P '/home/user/projects/workers' --worker-class custom.CustomWorker --job-class custom.CustomJob --name Custom