### PR TITLE
Replace job id with job instance in the job stack. Remove implicit "cleanup" call from "job.save"

### DIFF
--- a/rq/job.py
+++ b/rq/job.py
@@ -606,12 +606,9 @@ class Job(object):
             self.delete(pipeline=pipeline, remove_from_queue=remove_from_queue)
         elif not ttl:
             return
-        else:
+        elif ttl > 0:
             connection = pipeline if pipeline is not None else self.connection
-            if ttl > 0:
-                connection.expire(self.key, ttl)
-            else:
-                connection.persist(self.key)
+            connection.expire(self.key, ttl)
 
     def register_dependency(self, pipeline=None):
         """Jobs may have dependencies. Jobs are enqueued only if the job they

--- a/rq/queue.py
+++ b/rq/queue.py
@@ -223,6 +223,7 @@ class Queue(object):
                             job.set_status(JobStatus.DEFERRED)
                             job.register_dependency(pipeline=pipe)
                             job.save(pipeline=pipe)
+                            job.cleanup(ttl=job.ttl, pipeline=pipe)
                             pipe.execute()
                             return job
                         break
@@ -296,6 +297,7 @@ class Queue(object):
         if job.timeout is None:
             job.timeout = self.DEFAULT_TIMEOUT
         job.save(pipeline=pipe)
+        job.cleanup(ttl=job.ttl, pipeline=pipe)
 
         if self._async:
             self.push_job_id(job.id, pipeline=pipe, at_front=at_front)
@@ -492,6 +494,7 @@ class FailedQueue(Queue):
             job.ended_at = utcnow()
             job.exc_info = exc_info
             job.save(pipeline=pipeline, include_meta=False)
+            job.cleanup(ttl=-1, pipeline=pipeline)  # failed job won't expire
 
             self.push_job_id(job.id, pipeline=pipeline)
             pipeline.execute()

--- a/rq/registry.py
+++ b/rq/registry.py
@@ -93,6 +93,7 @@ class StartedJobRegistry(BaseRegistry):
                                                    connection=self.connection)
                         job.set_status(JobStatus.FAILED)
                         job.save(pipeline=pipeline, include_meta=False)
+                        job.cleanup(ttl=-1, pipeline=pipeline)
                         failed_queue.push_job_id(job_id, pipeline=pipeline)
                     except NoSuchJobError:
                         pass

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -386,7 +386,7 @@ class TestJob(RQTestCase):
         self.assertEqual(job.get_ttl(), ttl)
         job.save()
         job.perform()
-        self.assertEqual(job.get_ttl(), -1)
+        self.assertEqual(job.get_ttl(), ttl)
         self.assertTrue(job.exists(job.id))
         self.assertEqual(job.result, 'Done sleeping...')
 

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -654,9 +654,10 @@ class TestFailedQueue(RQTestCase):
     def test_job_in_failed_queue_persists(self):
         """Make sure failed job key does not expire"""
         q = Queue('foo')
-        job = q.enqueue(div_by_zero, args=(1, 2, 3), ttl=5)
+        job = q.enqueue(div_by_zero, args=(1,), ttl=5)
         self.assertEqual(self.testconn.ttl(job.key), 5) 
-        
+
+        self.assertRaises(ZeroDivisionError, job.perform)
         job.set_status(JobStatus.FAILED)
         failed_queue = get_failed_queue()
         failed_queue.quarantine(job, Exception('Some fake error'))

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -650,3 +650,15 @@ class TestFailedQueue(RQTestCase):
 
         job.delete()
         self.assertFalse(job.id in failed_queue.get_job_ids())
+
+    def test_job_in_failed_queue_persists(self):
+        """Make sure failed job key does not expire"""
+        q = Queue('foo')
+        job = q.enqueue(div_by_zero, args=(1, 2, 3), ttl=5)
+        self.assertEqual(self.testconn.ttl(job.key), 5) 
+        
+        job.set_status(JobStatus.FAILED)
+        failed_queue = get_failed_queue()
+        failed_queue.quarantine(job, Exception('Some fake error'))
+        
+        self.assertEqual(self.testconn.ttl(job.key), -1) 


### PR DESCRIPTION
As discussed [here](https://github.com/nvie/rq/pull/825#discussion_r114075946)