### PR TITLE
fix uncaught StopRequested during send heartbeat

### DIFF
--- a/rq/worker.py
+++ b/rq/worker.py
@@ -466,15 +466,15 @@ class Worker(object):
                         if burst:
                             self.log.info("RQ worker {0!r} done, quitting".format(self.key))
                         break
+                        
+                    job, queue = result
+                    self.execute_job(job, queue)
+                    self.heartbeat()
+                    
+                    did_perform_work = True
+                    
                 except StopRequested:
                     break
-
-                job, queue = result
-                self.execute_job(job, queue)
-                self.heartbeat()
-
-                did_perform_work = True
-
         finally:
             if not self.is_horse:
                 self.register_death()


### PR DESCRIPTION
I got this stack trace during a warm shutdown:

```
StopRequested: null
  File "rq/cli/cli.py", line 206, in worker
    w.work(burst=burst)
  File "rq/worker.py", line 461, in work
    self.heartbeat()
  File "rq/worker.py", line 510, in heartbeat
    connection.expire(self.key, timeout)
  File "redis/client.py", line 865, in expire
    return self.execute_command('EXPIRE', name, time)
  File "redis/client.py", line 573, in execute_command
    return self.parse_response(connection, command_name, **options)
  File "redis/client.py", line 585, in parse_response
    response = connection.read_response()
  File "redis/connection.py", line 577, in read_response
    response = self._parser.read_response()
  File "redis/connection.py", line 238, in read_response
    response = self._buffer.readline()
  File "redis/connection.py", line 168, in readline
    self._read_from_socket()
  File "redis/connection.py", line 126, in _read_from_socket
    data = self._sock.recv(socket_read_size)
  File "rq/worker.py", line 392, in request_stop
    raise StopRequested()
```

I trigger a warm shutdown while RQ sending heartbeat, It raise a uncaught StopRequested exception, this does not happen often, but it does happen.