### PR TITLE
Properly add exception stacktrace

### DIFF
--- a/rq/worker.py
+++ b/rq/worker.py
@@ -716,7 +716,7 @@ class Worker(object):
             self.handle_job_success(job=job,
                                     queue=queue,
                                     started_job_registry=started_job_registry)
-        except Exception:
+        except Exception as e:
             self.handle_job_failure(job=job,
                                     started_job_registry=started_job_registry)
             self.handle_exception(job, *sys.exc_info())
@@ -745,11 +745,13 @@ class Worker(object):
         exc_string = Worker._get_safe_exception_string(
             traceback.format_exception_only(*exc_info[:2]) + traceback.format_exception(*exc_info)
         )
-        self.log.error(exc_string, exc_info=True, extra={
+        self.log.error(exc_string, exc_info=exc_info, extra={
+            'job_id': job.id,
             'func': job.func_name,
             'arguments': job.args,
             'kwargs': job.kwargs,
             'queue': job.origin,
+            'description': job.description,
         })
 
         for handler in reversed(self._exc_handlers):


### PR DESCRIPTION
According to [logger docs](https://docs.python.org/3/library/logging.html#logging.Logger.debug):

> If exc_info does not evaluate as false, it causes exception information to be added to the logging message. If an exception tuple (in the format returned by sys.exc_info()) or an exception instance is provided, it is used; otherwise, sys.exc_info() is called to get the exception information.

**Note**

> New in version 3.2: The stack_info parameter was added.
> Changed in version 3.5: The exc_info parameter can now accept exception instances.

If you ever want to target newer python versions, those are better candidates