### PR TITLE
remove python 2.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: python
 services:
   - redis
 python:
-  - "2.6"
   - "2.7"
   - "3.3"
   - "3.4"
@@ -12,7 +11,6 @@ python:
   - "3.6-dev"
   - "pypy"
 install:
-  - if [[ $TRAVIS_PYTHON_VERSION == 2.6 ]]; then pip install -r py26-requirements.txt; fi
   - pip install -e .
   - pip install pytest-cov
   - pip install coveralls

--- a/py26-requirements.txt
+++ b/py26-requirements.txt
@@ -1,3 +1,0 @@
-unittest2
-importlib
-argparse

--- a/rq/logutils.py
+++ b/rq/logutils.py
@@ -11,13 +11,6 @@ def setup_loghandlers(level):
     logger = logging.getLogger('rq.worker')
     if not _has_effective_handler(logger):
         logger.setLevel(level)
-        # This statement doesn't set level properly in Python-2.6
-        # Following is an additional check to see if level has been set to
-        # appropriate(int) value
-        if logger.getEffectiveLevel() == level:
-            # Python-2.6. Set again by using logging.INFO etc.
-            level_int = getattr(logging, level)
-            logger.setLevel(level_int)
         formatter = logging.Formatter(fmt='%(asctime)s %(message)s',
                                       datefmt='%H:%M:%S')
         handler = ColorizingStreamHandler()

--- a/setup.py
+++ b/setup.py
@@ -16,16 +16,6 @@ def get_version():
     raise RuntimeError('No version info found.')
 
 
-def get_dependencies():
-    deps = ['redis >= 2.7.0', 'click >= 5.0']
-    if sys.version_info < (2, 7) or \
-            (sys.version_info >= (3, 0) and sys.version_info < (3, 1)):
-        deps += ['importlib']
-    if sys.version_info < (2, 7) or \
-            (sys.version_info >= (3, 0) and sys.version_info < (3, 2)):
-        deps += ['argparse']
-    return deps
-
 setup(
     name='rq',
     version=get_version(),
@@ -40,7 +30,11 @@ setup(
     include_package_data=True,
     zip_safe=False,
     platforms='any',
-    install_requires=get_dependencies(),
+    install_requires=[
+        'redis >= 2.7.0',
+        'click >= 5.0'
+    ],
+    python_requires='>=2.7',
     entry_points={
         'console_scripts': [
             'rq = rq.cli:main',
@@ -50,9 +44,6 @@ setup(
             'rqinfo = rq.cli:info',
             'rqworker = rq.cli:worker',
         ],
-    },
-    extras_require={
-        ':python_version=="2.6"': ['argparse', 'importlib'],
     },
     classifiers=[
         # As from http://pypi.python.org/pypi?%3Aaction=list_classifiers

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -11,6 +11,7 @@ import time
 from multiprocessing import Process
 import subprocess
 import sys
+from unittest import skipIf
 
 import pytest
 import mock
@@ -817,12 +818,9 @@ class TestWorkerSubprocess(RQTestCase):
         assert get_failed_queue().count == 0
         assert q.count == 0
 
-    # @skipIf('pypy' in sys.version.lower(), 'often times out with pypy')
+    @skipIf('pypy' in sys.version.lower(), 'often times out with pypy')
     def test_run_scheduled_access_self(self):
         """Schedule a job that schedules a job, then run the worker as subprocess"""
-        if 'pypy' in sys.version.lower():
-            # horrible bodge until we drop 2.6 support and can use skipIf
-            return
         q = Queue()
         q.enqueue(schedule_access_self)
         subprocess.check_call(['rqworker', '-u', self.redis_url, '-b'])


### PR DESCRIPTION
as per discussion #715 this removes python 2.6 support.

There are probably (definitely) lots of improvements possible now the syntax doesn't have to be stretched to support such a massive range of python versions, but this is a start.

**Rationale**: I was thinking about submitting a PR for #721 as someone suggested and realised that the reason I was unkeen was having to remember how an outdated version of python worked and maybe hack around to get python 2.6 installed to test the code. Removing this should make contributing to rq much easier for everyone.

Anyone still running 2.6 has much bigger problems than upgrading rq: they need to concentrate on upgrading to 2.7 and then 3 or scrapping their code-base and starting again.