### PR TITLE
Fixed #809 - Added tests for various cli config parameters

### DIFF
--- a/tests/dummy_settings_override.py
+++ b/tests/dummy_settings_override.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+REDIS_HOST = "testhost.example.com"
+REDIS_PORT = 6378
+REDIS_DB = 2
+REDIS_PASSWORD = '123'

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -62,6 +62,48 @@ class TestRQCli(RQTestCase):
         result = runner.invoke(main, ['info', '--config', cli_config.config])
         self.assertEqual(result.exit_code, 1)
 
+    def test_config_file_default_options(self):
+        """"""
+        cli_config = CliConfig(config='tests.dummy_settings')
+
+        self.assertEqual(
+            cli_config.connection.connection_pool.connection_kwargs['host'],
+            'testhost.example.com',
+        )
+        self.assertEqual(
+            cli_config.connection.connection_pool.connection_kwargs['port'],
+            6379
+        )
+        self.assertEqual(
+            cli_config.connection.connection_pool.connection_kwargs['db'],
+            0
+        )
+        self.assertEqual(
+            cli_config.connection.connection_pool.connection_kwargs['password'],
+            None
+        )
+
+    def test_config_file_default_options_override(self):
+        """"""
+        cli_config = CliConfig(config='tests.dummy_settings_override')
+
+        self.assertEqual(
+            cli_config.connection.connection_pool.connection_kwargs['host'],
+            'testhost.example.com',
+        )
+        self.assertEqual(
+            cli_config.connection.connection_pool.connection_kwargs['port'],
+            6378
+        )
+        self.assertEqual(
+            cli_config.connection.connection_pool.connection_kwargs['db'],
+            2
+        )
+        self.assertEqual(
+            cli_config.connection.connection_pool.connection_kwargs['password'],
+            '123'
+        )
+
     def test_empty_nothing(self):
         """rq empty -u <url>"""
         runner = CliRunner()


### PR DESCRIPTION
Tests show that the config parameters from a file do get passed in the Redis connection pool