### PR TITLE
try latin-1 if utf-8 doesn't work, when decoding exception strings

### DIFF
--- a/rq/worker.py
+++ b/rq/worker.py
@@ -779,7 +779,10 @@ class Worker(object):
     def _get_safe_exception_string(exc_strings):
         """Ensure list of exception strings is decoded on Python 2 and joined as one string safely."""
         if sys.version_info[0] < 3:
-            exc_strings = [exc.decode("utf-8") for exc in exc_strings]
+            try:
+                exc_strings = [exc.decode("utf-8") for exc in exc_strings]
+            except ValueError:
+                exc_strings = [exc.decode("latin-1") for exc in exc_strings]
         return ''.join(exc_strings)
 
     def push_exc_handler(self, handler_func):


### PR DESCRIPTION
Hi!

Recently we've had the issue, that an exception contained binary data in its message, which could not be decoded as utf-8. This PR uses latin-1 to decode the exception strings if utf-8 decoding fails.

Thanks for considering!