### PR TITLE
Fixed an issue where `birth` not present in Redis

### DIFF
--- a/rq/worker.py
+++ b/rq/worker.py
@@ -544,7 +544,10 @@ class Worker(object):
             self.last_heartbeat = utcparse(as_text(last_heartbeat))
         else:
             self.last_heartbeat = None
-        self.birth_date = utcparse(as_text(birth))
+        if birth:
+            self.birth_date = utcparse(as_text(birth))
+        else:
+            self.birth_date = None
         if failed_job_count:
             self.failed_job_count = int(as_text(failed_job_count))
         if successful_job_count:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -202,16 +202,21 @@ class TestWorker(RQTestCase):
         q = Queue()
         w = Worker([q])
         w.register_birth()
+        birth = self.testconn.hget(w.key, 'birth')
         last_heartbeat = self.testconn.hget(w.key, 'last_heartbeat')
-
+        self.assertTrue(birth is not None)
         self.assertTrue(last_heartbeat is not None)
         w = Worker.find_by_key(w.key)
-        self.assertIsInstance(w.last_heartbeat, datetime)   
+        self.assertIsInstance(w.last_heartbeat, datetime)
 
         # worker.refresh() shouldn't fail if last_heartbeat is None
         # for compatibility reasons
-        self.testconn.hdel(w.key, 'last_heartbeat')        
-        w.refresh()     
+        self.testconn.hdel(w.key, 'last_heartbeat')
+        w.refresh()
+        # worker.refresh() shouldn't fail if birth is None
+        # for compatibility reasons
+        self.testconn.hdel(w.key, 'birth')
+        w.refresh()
 
     def test_work_fails(self):
         """Failing jobs are put on the failed queue."""


### PR DESCRIPTION
Fixed an issue where worker.refresh() may fail if `birth` is not present in Redis.