### PR TITLE
improve logging in worker.py

### DIFF
--- a/rq/worker.py
+++ b/rq/worker.py
@@ -94,6 +94,8 @@ class Worker(object):
     death_penalty_class = UnixSignalDeathPenalty
     queue_class = Queue
     job_class = Job
+    # `log_result_lifespan` controls whether "Result is kept for XXX seconds"
+    # messages are logged after every job, by default they are.
     log_result_lifespan = True
 
     @classmethod

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -727,6 +727,30 @@ class TestWorker(RQTestCase):
         self.assertEqual(job_check.meta['baz'], 10)
         self.assertEqual(job_check.meta['newinfo'], 'waka')
 
+    @mock.patch('rq.worker.logger.info')
+    def test_log_result_lifespan_true(self, mock_logger_info):
+        """Check that log_result_lifespan True causes job lifespan to be logged."""
+        q = Queue()
+
+        w = Worker([q])
+        job = q.enqueue(say_hello, args=('Frank',), result_ttl=10)
+        w.perform_job(job, q)
+        mock_logger_info.assert_called_with('Result is kept for 10 seconds')
+        self.assertIn('Result is kept for 10 seconds', [c[0][0] for c in mock_logger_info.call_args_list])
+
+    @mock.patch('rq.worker.logger.info')
+    def test_log_result_lifespan_false(self, mock_logger_info):
+        """Check that log_result_lifespan False causes job lifespan to not be logged."""
+        q = Queue()
+
+        class TestWorker(Worker):
+            log_result_lifespan = False
+
+        w = TestWorker([q])
+        job = q.enqueue(say_hello, args=('Frank',), result_ttl=10)
+        w.perform_job(job, q)
+        self.assertNotIn('Result is kept for 10 seconds', [c[0][0] for c in mock_logger_info.call_args_list])
+
 
 def kill_worker(pid, double_kill):
     # wait for the worker to be started over on the main process


### PR DESCRIPTION
Worker logging is currently pretty verbose and naively configured. 

This improves it.

Changes:
* logging `*** Listening on ...` before/after every job moved from INFO to DEBUG
* logging `*** Listening on ...` at INFO on initial load.
* `log_result_lifespan` to prevent, `Result is kept for 500 seconds` being logged for every job
* whoever initially implemented logging in `worker` apparently didn't take the time to look at how python logging works - it specifically allows `log.info('template with var %s', var)` syntax to avoid formatting log statements which are subsequently dropped. I've fixed this on all `DEBUG` log statements, as that will have the most effect since they're generally dropped.
* there was a bunch of white space at the end of lines (is rq not running linting !?) which pycharm automatically deleted.

Currently executing a job with rq causes 4 statements at INFO level. This is currently causing about 1GB of logs each month from rq alone.

I can add a test for `log_result_lifespan` if you're happy with this.