### PR TITLE
Add description param to  @job decorator

### DIFF
--- a/rq/decorators.py
+++ b/rq/decorators.py
@@ -16,7 +16,8 @@ class job(object):  # noqa
 
     def __init__(self, queue, connection=None, timeout=None,
                  result_ttl=DEFAULT_RESULT_TTL, ttl=None,
-                 queue_class=None, depends_on=None, at_front=None, meta=None):
+                 queue_class=None, depends_on=None, at_front=None, meta=None,
+                 description=None):
         """A decorator that adds a ``delay`` method to the decorated function,
         which in turn creates a RQ job when called. Accepts a required
         ``queue`` argument that can be either a ``Queue`` instance or a string
@@ -37,6 +38,7 @@ class job(object):  # noqa
         self.meta = meta
         self.depends_on = depends_on
         self.at_front = at_front
+        self.description = description
 
     def __call__(self, f):
         @wraps(f)
@@ -59,6 +61,6 @@ class job(object):  # noqa
             return queue.enqueue_call(f, args=args, kwargs=kwargs,
                                       timeout=self.timeout, result_ttl=self.result_ttl,
                                       ttl=self.ttl, depends_on=depends_on, at_front=at_front,
-                                      meta=self.meta)
+                                      meta=self.meta, description=self.description)
         f.delay = delay
         return f


### PR DESCRIPTION
After using `@job` decorator for a function that takes a long string, in RQ worker I got printed all the args/kwargs via `job.get_call_string()`.

To get this overridden, I added `description` argument to the decorator.

I decided not to put this in `delay` method because it's may be currently be used by end user.